### PR TITLE
feat: add chat context provider with session persistence

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,41 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Header from './components/Header';
 import ConversationPane from './components/ConversationPane';
 import Composer from './components/Composer';
 import SystemNotices from './components/SystemNotices';
 import Footer from './components/Footer';
-
-export interface Message {
-  role: 'user' | 'assistant';
-  content: string;
-}
+import { useChat } from './chat';
 
 function App() {
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [notices, setNotices] = useState<any>(null);
-
-  const send = (text: string) => {
-    setMessages((msgs) => [...msgs, { role: 'user', content: text }, { role: 'assistant', content: '' }]);
-    const es = new EventSource(`/api/chat?q=${encodeURIComponent(text)}`);
-    es.addEventListener('token', (e) => {
-      const token = (e as MessageEvent).data;
-      setMessages((msgs) => {
-        const updated = [...msgs];
-        const last = updated[updated.length - 1];
-        updated[updated.length - 1] = { ...last, content: last.content + token };
-        return updated;
-      });
-    });
-    es.addEventListener('sources', (e) => {
-      setNotices(JSON.parse((e as MessageEvent).data));
-    });
-    es.addEventListener('done', () => {
-      es.close();
-    });
-    es.addEventListener('error', () => {
-      es.close();
-    });
-  };
+  const { messages, notices, send } = useChat();
 
   return (
     <div className="app">

--- a/frontend/src/chat.tsx
+++ b/frontend/src/chat.tsx
@@ -1,0 +1,88 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+  status?: 'streaming' | 'done';
+}
+
+interface ChatContextValue {
+  messages: Message[];
+  notices: any;
+  sessionId: string;
+  isStreaming: boolean;
+  send: (text: string) => void;
+}
+
+const ChatContext = createContext<ChatContextValue | undefined>(undefined);
+
+export function ChatProvider({ children }: { children: React.ReactNode }) {
+  const [messages, setMessages] = useState<Message[]>(() => {
+    const stored = localStorage.getItem('messages');
+    return stored ? JSON.parse(stored) : [];
+  });
+  const [notices, setNotices] = useState<any>(null);
+  const [sessionId, setSessionId] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  useEffect(() => {
+    let id = localStorage.getItem('sessionId');
+    if (!id) {
+      id = crypto.randomUUID();
+      localStorage.setItem('sessionId', id);
+    }
+    setSessionId(id);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('messages', JSON.stringify(messages));
+  }, [messages]);
+
+  const send = (text: string) => {
+    setMessages((msgs) => [
+      ...msgs,
+      { role: 'user', content: text },
+      { role: 'assistant', content: '', status: 'streaming' },
+    ]);
+    setIsStreaming(true);
+    const es = new EventSource(`/api/chat?q=${encodeURIComponent(text)}&sessionId=${sessionId}`);
+    es.addEventListener('token', (e) => {
+      const token = (e as MessageEvent).data;
+      setMessages((msgs) => {
+        const updated = [...msgs];
+        const last = updated[updated.length - 1];
+        updated[updated.length - 1] = { ...last, content: last.content + token };
+        return updated;
+      });
+    });
+    es.addEventListener('sources', (e) => {
+      setNotices(JSON.parse((e as MessageEvent).data));
+    });
+    es.addEventListener('done', () => {
+      setIsStreaming(false);
+      setMessages((msgs) => {
+        const updated = [...msgs];
+        const last = updated[updated.length - 1];
+        updated[updated.length - 1] = { ...last, status: 'done' };
+        return updated;
+      });
+      es.close();
+    });
+    es.addEventListener('error', () => {
+      setIsStreaming(false);
+      es.close();
+    });
+  };
+
+  return (
+    <ChatContext.Provider value={{ messages, notices, sessionId, isStreaming, send }}>
+      {children}
+    </ChatContext.Provider>
+  );
+}
+
+export function useChat() {
+  const ctx = useContext(ChatContext);
+  if (!ctx) throw new Error('useChat must be used within ChatProvider');
+  return ctx;
+}

--- a/frontend/src/components/ConversationPane.tsx
+++ b/frontend/src/components/ConversationPane.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import MarkdownIt from 'markdown-it';
 import DOMPurify from 'dompurify';
-import { Message } from '../App';
+import { Message } from '../chat';
 
 const md = new MarkdownIt();
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { ChatProvider } from './chat';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ChatProvider>
+      <App />
+    </ChatProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- create chat context hook to manage messages, streaming state, and session id
- initialize session id from localStorage and persist message history
- wrap app with provider and update components to use centralized chat state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a391da05848323b5e68bb503125af6