### PR TITLE
feat: add branding support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -55,6 +55,17 @@ async def health():
     return {"status": "ok"}
 
 
+@app.get("/api/config")
+async def config():
+    return {
+        "BRAND_NAME": os.getenv("BRAND_NAME", "PDF Knowledge Kit"),
+        "POWERED_BY_LABEL": os.getenv(
+            "POWERED_BY_LABEL", "Powered by PDF Knowledge Kit"
+        ),
+        "LOGO_URL": os.getenv("LOGO_URL", ""),
+    }
+
+
 @app.post("/api/upload")
 async def upload(
     background_tasks: BackgroundTasks, file: UploadFile = File(...)

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,3 +1,6 @@
+import { useConfig } from '../config';
+
 export default function Footer() {
-  return <footer>&copy; PDF Knowledge Kit</footer>;
+  const { POWERED_BY_LABEL } = useConfig();
+  return <footer>{POWERED_BY_LABEL}</footer>;
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,7 +1,11 @@
+import { useConfig } from '../config';
+
 export default function Header() {
+  const { BRAND_NAME, LOGO_URL } = useConfig();
   return (
     <header>
-      <h1>PDF Knowledge Kit</h1>
+      {LOGO_URL && <img src={LOGO_URL} alt={BRAND_NAME} className="logo" />}
+      <h1>{BRAND_NAME}</h1>
     </header>
   );
 }

--- a/frontend/src/config.tsx
+++ b/frontend/src/config.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export interface AppConfig {
+  BRAND_NAME: string;
+  POWERED_BY_LABEL: string;
+  LOGO_URL: string;
+}
+
+const defaultConfig: AppConfig = {
+  BRAND_NAME: 'PDF Knowledge Kit',
+  POWERED_BY_LABEL: 'Powered by PDF Knowledge Kit',
+  LOGO_URL: '',
+};
+
+const ConfigContext = createContext<AppConfig>(defaultConfig);
+
+export function ConfigProvider({ children }: { children: React.ReactNode }) {
+  const [config, setConfig] = useState<AppConfig>(() => {
+    const injected = (window as any).__CONFIG__ || {};
+    return { ...defaultConfig, ...injected } as AppConfig;
+  });
+
+  useEffect(() => {
+    fetch('/api/config')
+      .then((res) => (res.ok ? res.json() : {}))
+      .then((data) => setConfig((prev) => ({ ...prev, ...data })))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+  );
+}
+
+export function useConfig() {
+  return useContext(ConfigContext);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { ChatProvider } from './chat';
+import { ConfigProvider } from './config';
+import './theme.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <ChatProvider>
-      <App />
-    </ChatProvider>
+    <ConfigProvider>
+      <ChatProvider>
+        <App />
+      </ChatProvider>
+    </ConfigProvider>
   </React.StrictMode>
 );

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1,0 +1,46 @@
+:root {
+  --brand-bg: #ffffff;
+  --brand-fg: #000000;
+  --brand-accent: #007bff;
+}
+
+body {
+  margin: 0;
+  background-color: var(--brand-bg);
+  color: var(--brand-fg);
+  font-family: sans-serif;
+}
+
+header,
+footer {
+  background-color: var(--brand-accent);
+  color: var(--brand-bg);
+  padding: 1rem;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+header img.logo {
+  height: 40px;
+}
+
+button {
+  background-color: var(--brand-accent);
+  color: var(--brand-bg);
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.composer textarea {
+  background-color: var(--brand-bg);
+  color: var(--brand-fg);
+}
+
+a {
+  color: var(--brand-accent);
+}


### PR DESCRIPTION
## Summary
- add theme.css with brand color CSS variables
- display brand name, logo, and footer label from config
- expose `/api/config` to supply branding values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3a05e4a5083239ba8c2a8a205c61c