### PR TITLE
Add app service and proxy configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,13 @@ PGPASSWORD=pdfkb
 
 # Pasta padrão dos PDFs (pode usar --docs no ingest.py)
 DOCS_DIR=./docs
+
+# Configurações da aplicação
+USE_LLM=true
+OPENAI_API_KEY=
+TOP_K=5
+MAX_CONTEXT_CHARS=3000
+CORS_ALLOW_ORIGINS=*
+BRAND_NAME=PDF Knowledge Kit
+POWERED_BY_LABEL=Powered by PDF Knowledge Kit
+LOGO_URL=

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,6 @@
+example.com {
+    reverse_proxy app:8000
+    header {
+        Cache-Control "no-transform"
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,11 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./docs:/app/docs:ro
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- add app service to docker-compose with port 8000 and docs volume
- expand env example with application settings
- provide Dockerfile and Caddyfile for HTTPS reverse proxy

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3bb4770748323a7c388d3038f01cd