### PR TITLE
docs: add chat build guide and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,37 @@ python ingest.py --docs ./docs
 python query.py --q "Como configuro potência de leitura?" --k 5
 ```
 
+## Build do chat e frontend
+
+```bash
+# Backend standalone
+uvicorn app.main:app --reload  # roda em http://localhost:8000
+
+# ou construa tudo com Docker
+docker compose up --build
+
+# Frontend (opcional para alterar a interface)
+cd frontend
+npm install
+npm run build  # gera os arquivos em app/static
+```
+
+## Variáveis de ambiente
+Copie `.env.example` para `.env` e ajuste conforme necessário:
+
+- **PGHOST**, **PGPORT**, **PGDATABASE**, **PGUSER**, **PGPASSWORD** – conexão com o Postgres/pgvector.
+- **DOCS_DIR** – pasta padrão para os PDFs.
+- **OPENAI_API_KEY**, **OPENAI_MODEL**, **USE_LLM** – integrações com LLM (opcional).
+- **TOP_K**, **MAX_CONTEXT_CHARS** – ajustes de recuperação de trechos.
+- **UPLOAD_DIR**, **UPLOAD_TTL**, **UPLOAD_MAX_SIZE**, **UPLOAD_ALLOWED_MIME_TYPES** – controle de uploads temporários.
+- **CORS_ALLOW_ORIGINS**, **BRAND_NAME**, **POWERED_BY_LABEL**, **LOGO_URL** – personalização da UI.
+
+## Uso do chat
+1. Garanta que o backend esteja rodando (com `uvicorn` ou Docker).
+2. Acesse `http://localhost:8000` no navegador.
+3. Envie mensagens pelo campo de texto. Opcionalmente, anexe um PDF pequeno para enriquecer o contexto.
+4. Durante a geração da resposta, use **Cancelar** para interromper o streaming e **Enviar** novamente para retomar.
+
 ## Estrutura
 ```
 pdf_knowledge_kit/
@@ -61,6 +92,13 @@ pdf_knowledge_kit/
 - PDFs escaneados (sem texto) exigem **OCR** (ex.: Tesseract). Este kit não faz OCR por padrão — adicione se precisar.
 - Para lotes grandes (milhares de páginas), rode ingestão em *batches* e crie o índice **depois**.
 - Se já usa Postgres no seu stack, pgvector é simples e barato. Se quiser um serviço dedicado, olhe **Qdrant** ou **Weaviate**.
+ 
+## Critérios de acessibilidade e desempenho
+- Texto alternativo e rótulos ARIA para componentes interativos.
+- Navegação total por teclado e foco visível.
+- Contraste mínimo de 4.5:1 nas cores da interface.
+- Respostas transmitidas via **SSE** para reduzir latência.
+- Limpeza automática de uploads e limites de tamanho para preservar recursos.
 
 Boa construção! 🚀
 (gerado em 2025-08-18)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ fastapi>=0.110
 sse-starlette>=1.6
 openai>=1.0
 python-multipart>=0.0.7
+pytest>=8.0

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,94 @@
+import io
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyEmbedder:
+    def embed(self, texts):
+        return [[0.0] * 384 for _ in texts]
+
+
+# Stub fastembed before importing the app to avoid model downloads.
+sys.modules['fastembed'] = types.SimpleNamespace(
+    TextEmbedding=lambda model_name: DummyEmbedder()
+)
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.main import app
+from starlette.routing import Mount
+
+# Remove static mount to access API routes during tests
+app.router.routes = [r for r in app.router.routes if not (isinstance(r, Mount) and r.path == '')]
+
+
+def dummy_build_context(q, k):
+    return "context", [
+        {"path": "doc.pdf", "chunk_index": 0, "content": "context", "distance": 0.0}
+    ]
+
+
+def _parse_events(resp):
+    events = []
+    current = None
+    for line in resp.iter_lines():
+        if not line:
+            continue
+        if isinstance(line, bytes):
+            line = line.decode()
+        if line.startswith("event:"):
+            current = line.split(":", 1)[1].strip()
+        elif line.startswith("data:") and current:
+            events.append((current, line.split(":", 1)[1].strip()))
+            current = None
+    return events
+
+
+def _pdf_bytes():
+    from pypdf import PdfWriter
+
+    buf = io.BytesIO()
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.write(buf)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_chat_without_attachment(client):
+    with patch("app.main.build_context", dummy_build_context):
+        with client.stream("POST", "/api/chat", data={"q": "hi", "k": "1"}) as resp:
+            events = _parse_events(resp)
+    assert any(e[0] == "token" for e in events)
+    assert any(e[0] == "done" for e in events)
+
+
+def test_chat_with_pdf_attachment(client):
+    files = {"files": ("test.pdf", _pdf_bytes(), "application/pdf")}
+    data = {"q": "hi", "k": "1", "attachments": "[]"}
+    with patch("app.main.build_context", dummy_build_context):
+        with client.stream("POST", "/api/chat", data=data, files=files) as resp:
+            events = _parse_events(resp)
+    assert any(e[0] == "token" for e in events)
+    assert any(e[0] == "done" for e in events)
+
+
+def test_cancel_and_reconnect(client):
+    with patch("app.main.build_context", dummy_build_context):
+        with client.stream("POST", "/api/chat", data={"q": "hi", "k": "1"}) as resp:
+            for _ in resp.iter_lines():
+                break  # cancel early
+        with client.stream("POST", "/api/chat", data={"q": "again", "k": "1"}) as resp2:
+            events = _parse_events(resp2)
+    assert any(e[0] == "token" for e in events)
+    assert any(e[0] == "done" for e in events)
+


### PR DESCRIPTION
## Summary
- document chat build steps, env vars and accessibility criteria
- add integration tests for chat message, attachment and cancel flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd3943308323a28ed908cbe17c1f