### PR TITLE
feat: validate chat inputs and rate limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ sse-starlette>=1.6
 openai>=1.0
 python-multipart>=0.0.7
 pytest>=8.0
+slowapi>=0.1.8


### PR DESCRIPTION
## Summary
- validate chat message length, session IDs, and attachment MIME types
- add simple rate limiting to chat endpoint
- extend tests for new validation and limiting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3c23681f88323a1a7763a1d4e341b