### PR TITLE
Implement LLM-backed ask endpoint

### DIFF
--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1,0 +1,67 @@
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyEmbedder:
+    def embed(self, texts):
+        return [[0.0] * 384 for _ in texts]
+
+
+# Stub fastembed before importing the app to avoid model downloads.
+sys.modules['fastembed'] = types.SimpleNamespace(
+    TextEmbedding=lambda model_name: DummyEmbedder()
+)
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.main import app
+from starlette.routing import Mount
+
+# Remove static mount to access API routes during tests
+app.router.routes = [r for r in app.router.routes if not (isinstance(r, Mount) and r.path == '')]
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def dummy_build_context(q, k):
+    return "context", [
+        {"path": "doc.pdf", "chunk_index": 0, "content": "context", "distance": 0.0}
+    ]
+
+
+def test_ask_without_llm(client):
+    with patch("app.main.build_context", dummy_build_context), patch("app.main.client", None):
+        resp = client.post("/api/ask", json={"q": "hi", "k": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == "context"
+    assert data["used_llm"] is False
+    assert data["sources"]
+
+
+def test_ask_with_llm(client):
+    class DummyCompletion:
+        def __init__(self):
+            self.choices = [types.SimpleNamespace(message={"content": "llm"})]
+
+    class DummyClient:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self.create))
+
+        def create(self, **kwargs):
+            return DummyCompletion()
+
+    with patch("app.main.build_context", dummy_build_context), patch("app.main.client", DummyClient()):
+        resp = client.post("/api/ask", json={"q": "hi", "k": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == "llm"
+    assert data["used_llm"] is True
+    assert data["sources"]


### PR DESCRIPTION
## Summary
- Reuse RAG utilities to let `/api/ask` query the knowledge base and optional LLM for final answers
- Return `{answer, sources, used_llm}` in the ask response
- Add tests covering the ask endpoint with and without an LLM client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3c527886c83238414b539ca835c34