### PR TITLE
Add uvicorn dependency for Docker app startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ fastembed>=0.3.3
 tqdm>=4.66
 fastapi>=0.110
 sse-starlette>=1.6
+uvicorn>=0.29
 openai>=1.0
 python-multipart>=0.0.7
 pytest>=8.0


### PR DESCRIPTION
## Summary
- Include `uvicorn` in requirements so Docker container can run the FastAPI app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49c9b0b888323a151763c9592b544