### PR TITLE
Fix FastEmbed model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Crie rapidamente uma base de conhecimento a partir de **arquivos PDF** em uma pa
 4. **Armazena** em **PostgreSQL + pgvector**.
 5. **Consulta** por similaridade (kNN) com `query.py` — pronto para integrar no seu agente.
 
-> Dimensão dos vetores: **384** (modelo `intfloat/multilingual-e5-small`).
+> Dimensão dos vetores: **384** (modelo `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`).
 
 ---
 

--- a/app/rag.py
+++ b/app/rag.py
@@ -4,7 +4,8 @@ from pgvector.psycopg import register_vector
 from fastembed import TextEmbedding
 from typing import List, Tuple, Dict
 
-embedder = TextEmbedding(model_name="intfloat/multilingual-e5-small")
+# Use a supported multilingual embedding model
+embedder = TextEmbedding(model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
 
 
 def get_conn():

--- a/ingest.py
+++ b/ingest.py
@@ -113,7 +113,8 @@ def main():
         print(f"[INFO] Nenhum PDF encontrado em {docs_dir.resolve()}")
         return
 
-    embedder = TextEmbedding(model_name="intfloat/multilingual-e5-small")
+    # Use a supported multilingual embedding model
+    embedder = TextEmbedding(model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
 
     for pdf_path in tqdm(pdf_files, desc="Processando PDFs"):
         try:

--- a/query.py
+++ b/query.py
@@ -19,7 +19,8 @@ def main():
     conn = psycopg.connect(dsn)
     register_vector(conn)
 
-    embedder = TextEmbedding(model_name="intfloat/multilingual-e5-small")
+    # Use a supported multilingual embedding model
+    embedder = TextEmbedding(model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
     qvec = list(embedder.embed([f'query: {args.q}']))[0]  # E5 prefix para consulta
 
     sql = """

--- a/schema.sql
+++ b/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS documents (
 );
 
 -- Tabela de chunks
--- Dimensão 384 para o modelo 'intfloat/multilingual-e5-small'
+-- Dimensão 384 para o modelo 'sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2'
 CREATE TABLE IF NOT EXISTS chunks (
   id BIGSERIAL PRIMARY KEY,
   doc_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- replace unsupported `intfloat/multilingual-e5-small` with supported `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
- document new embedding model in README and schema comments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49efc3ad883238458ccb7867160bb