### PR TITLE
Use Docker db hostname for Postgres connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Conexão com Postgres/pgvector
-PGHOST=localhost
+# Use o hostname do serviço definido no docker-compose (por padrão: db)
+PGHOST=db
 PGPORT=5432
 PGDATABASE=pdfkb
 PGUSER=pdfkb

--- a/app/rag.py
+++ b/app/rag.py
@@ -10,7 +10,7 @@ embedder = TextEmbedding(model_name="sentence-transformers/paraphrase-multilingu
 
 def get_conn():
     dsn = (
-        f"host={os.getenv('PGHOST','localhost')} "
+        f"host={os.getenv('PGHOST','db')} "
         f"port={os.getenv('PGPORT','5432')} "
         f"dbname={os.getenv('PGDATABASE','pdfkb')} "
         f"user={os.getenv('PGUSER','pdfkb')} "

--- a/ingest.py
+++ b/ingest.py
@@ -102,7 +102,7 @@ def main():
     parser.add_argument("--reindex", action="store_true", help="Recria índice vetorial após ingestão")
     args = parser.parse_args()
 
-    dsn = f"host={os.getenv('PGHOST','localhost')} port={os.getenv('PGPORT','5432')} dbname={os.getenv('PGDATABASE','pdfkb')} user={os.getenv('PGUSER','pdfkb')} password={os.getenv('PGPASSWORD','pdfkb')}"
+    dsn = f"host={os.getenv('PGHOST','db')} port={os.getenv('PGPORT','5432')} dbname={os.getenv('PGDATABASE','pdfkb')} user={os.getenv('PGUSER','pdfkb')} password={os.getenv('PGPASSWORD','pdfkb')}"
     conn = psycopg.connect(dsn)
     register_vector(conn)
     ensure_schema(conn, Path(__file__).with_name("schema.sql"))

--- a/query.py
+++ b/query.py
@@ -15,7 +15,7 @@ def main():
     parser.add_argument("--k", type=int, default=5, help="Número de trechos retornados")
     args = parser.parse_args()
 
-    dsn = f"host={os.getenv('PGHOST','localhost')} port={os.getenv('PGPORT','5432')} dbname={os.getenv('PGDATABASE','pdfkb')} user={os.getenv('PGUSER','pdfkb')} password={os.getenv('PGPASSWORD','pdfkb')}"
+    dsn = f"host={os.getenv('PGHOST','db')} port={os.getenv('PGPORT','5432')} dbname={os.getenv('PGDATABASE','pdfkb')} user={os.getenv('PGUSER','pdfkb')} password={os.getenv('PGPASSWORD','pdfkb')}"
     conn = psycopg.connect(dsn)
     register_vector(conn)
 


### PR DESCRIPTION
## Summary
- default Postgres host to `db` for Docker deployment
- document service-based hostname in `.env.example`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a0d6a0fc8323bc3e31ff42594532