### PR TITLE
Add OCR dependencies and system packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM python:3.12-slim
 WORKDIR /app
+
+# Install system dependencies for OCR
+RUN apt-get update && apt-get install -y \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    tesseract-ocr-por \
+    poppler-utils \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ openai>=1.0
 python-multipart>=0.0.7
 pytest>=8.0
 slowapi>=0.1.8
+pytesseract
+pdf2image
+Pillow


### PR DESCRIPTION
## Summary
- include pytesseract, pdf2image, and Pillow in requirements
- install tesseract OCR, language packs, and poppler utilities in the Docker image

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `docker build -t pdf-knowledge-kit .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ad7b48a8832395df23e427cb429a