### PR TITLE
Add Spanish OCR language data to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     tesseract-ocr \
     tesseract-ocr-eng \
     tesseract-ocr-por \
+    tesseract-ocr-spa \
     poppler-utils \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- include Spanish OCR language package in Dockerfile

## Testing
- `pytest`
- `docker build -t pdf-knowledge-kit:latest .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bd78e3708323aedb6dc76544ab79