### PR TITLE
Add tests for multilingual Markdown ingestion

### DIFF
--- a/tests/md_samples/sample_en.md
+++ b/tests/md_samples/sample_en.md
@@ -1,0 +1,3 @@
+# English Sample
+
+This is a sample markdown file in English.

--- a/tests/md_samples/sample_es.md
+++ b/tests/md_samples/sample_es.md
@@ -1,0 +1,3 @@
+# Ejemplo en Español
+
+Este es un archivo markdown de ejemplo en español.

--- a/tests/md_samples/sample_pt.md
+++ b/tests/md_samples/sample_pt.md
@@ -1,0 +1,3 @@
+# Exemplo em Português
+
+Este é um arquivo markdown de exemplo em português.

--- a/tests/test_ingest_md.py
+++ b/tests/test_ingest_md.py
@@ -1,0 +1,27 @@
+import pathlib
+import ingest
+
+
+class DummyEmbedder:
+    def embed(self, texts):
+        return [[0.0] * 384 for _ in texts]
+
+
+import pytest
+
+
+@pytest.mark.parametrize("fname", ["sample_en.md", "sample_pt.md", "sample_es.md"])
+def test_read_chunk_embed_markdown(fname, monkeypatch):
+    path = pathlib.Path(__file__).parent / "md_samples" / fname
+
+    text = ingest.read_md_text(path)
+    assert text.strip() != ""
+
+    chunks = ingest.chunk_text(text)
+    assert chunks
+
+    monkeypatch.setattr(ingest, "TextEmbedding", lambda model_name: DummyEmbedder())
+    embedder = ingest.TextEmbedding(model_name=ingest.EMBEDDING_MODEL)
+
+    vectors = list(embedder.embed(chunks))
+    assert len(vectors) == len(chunks)


### PR DESCRIPTION
## Summary
- add Markdown samples in English, Portuguese, and Spanish
- test ingest.read_md_text, chunking, and embedding for multilingual Markdown

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d370152c8323aacd825975e190a3