### PR TITLE
Initialize logging after FastAPI instantiation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 
 from .rag import build_context
+from .app_logging import init_logging
 
 try:
     from openai import OpenAI
@@ -53,6 +54,7 @@ def get_client_ip(request: Request) -> str:
 limiter = Limiter(key_func=get_client_ip)
 
 app = FastAPI()
+init_logging(app)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)

--- a/tests/test_init_logging.py
+++ b/tests/test_init_logging.py
@@ -1,0 +1,44 @@
+import logging
+from logging.handlers import TimedRotatingFileHandler
+
+from fastapi import FastAPI
+
+from app.app_logging import init_logging
+
+
+def _clear_handlers(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    return logger
+
+
+def test_init_logging_adds_handlers(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    app_logger = _clear_handlers("app")
+    access_logger = _clear_handlers("uvicorn.access")
+
+    app = FastAPI()
+    init_logging(app)
+
+    assert any(
+        isinstance(h, TimedRotatingFileHandler) for h in app_logger.handlers
+    )
+    assert any(
+        isinstance(h, TimedRotatingFileHandler) for h in access_logger.handlers
+    )
+
+    app_logger.handlers.clear()
+    access_logger.handlers.clear()
+
+
+def test_init_logging_preserves_existing_access_handlers(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOG_DIR", str(tmp_path))
+    access_logger = _clear_handlers("uvicorn.access")
+
+    stream_handler = logging.StreamHandler()
+    access_logger.addHandler(stream_handler)
+
+    init_logging()
+
+    assert access_logger.handlers == [stream_handler]
+    access_logger.handlers.clear()


### PR DESCRIPTION
## Summary
- import and invoke `init_logging(app)` immediately after creating the FastAPI app
- add tests confirming logging handlers for development and production setups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4de060ce0832390356dcbf8f74ed0