### PR TITLE
feat: add logging configuration and persistence instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,14 @@ BRAND_NAME=PDF Knowledge Kit
 POWERED_BY_LABEL=Powered by PDF Knowledge Kit
 LOGO_URL=
 
+# Configuracoes de log
+LOG_DIR=/var/log/app
+LOG_LEVEL=INFO
+LOG_JSON=false
+LOG_RETENTION_DAYS=7
+LOG_ROTATE_UTC=true
+LOG_REQUEST_BODIES=false
+
 # OCR (opcional)
 # ENABLE_OCR=1
 # OCR_LANG=eng+por+spa

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN apt-get update && apt-get install -y \
     tesseract-ocr-spa \
     poppler-utils \
  && rm -rf /var/lib/apt/lists/*
+# Prepare log directory
+RUN mkdir -p /var/log/app && \
+    chown -R root:root /var/log/app && \
+    chmod 755 /var/log/app
 
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ python query.py --q "Como configuro potência de leitura?" --k 5
      app python ingest.py --docs /app/docs  # adicione --ocr ou ENABLE_OCR=1 se preciso
    ```
 
+
+## Logs
+
+Os logs da aplicação são gravados em `/var/log/app` dentro do container.
+Para mantê-los no host, mapeie um volume:
+
+```yaml
+  app:
+    volumes:
+      - ./logs:/var/log/app
+```
+
+O diretório `./logs` passará a conter os arquivos de log.
+
 ## Build do chat e frontend
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - "8000:8000"
     volumes:
       - ./docs:/app/docs:ro
+      - ./logs:/var/log/app  # Persist application logs
       # - ./tessdata:/usr/share/tesseract-ocr/tessdata:ro  # Uncomment to provide custom language data
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- add logging environment variables
- ensure container prepares /var/log/app with proper ownership
- map logs to host and document volume

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4dfcf5aa8832389cfa92d6ae174de