### PR TITLE
Add comprehensive logging tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import pathlib
+import sys
+
+import pytest
+from fastapi import FastAPI, Request
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app.app_logging import init_logging
+
+
+@pytest.fixture
+def app_factory(monkeypatch):
+    def _create_app(log_dir: str, log_request_bodies: bool = False):
+        """Create a FastAPI app with logging initialised."""
+        monkeypatch.setenv("LOG_DIR", str(log_dir))
+        if log_request_bodies:
+            monkeypatch.setenv("LOG_REQUEST_BODIES", "true")
+        app = FastAPI()
+
+        @app.post("/echo")
+        async def echo(request: Request):
+            return await request.json()
+
+        init_logging(app)
+        return app
+
+    return _create_app

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,83 @@
+import json
+import logging
+import tempfile
+from pathlib import Path
+from logging.handlers import TimedRotatingFileHandler
+
+import pytest
+from starlette.testclient import TestClient
+
+from app.app_logging import init_logging
+
+
+def _clear_handlers(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    return logger
+
+
+@pytest.fixture
+def log_dir(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setenv("LOG_DIR", tmpdir)
+        yield Path(tmpdir)
+
+
+def test_timed_rotating_handler_configuration(log_dir, monkeypatch):
+    monkeypatch.setenv("LOG_RETENTION_DAYS", "5")
+    app_logger = _clear_handlers("app")
+    access_logger = _clear_handlers("uvicorn.access")
+
+    init_logging()
+
+    app_handler = next(
+        h for h in app_logger.handlers if isinstance(h, TimedRotatingFileHandler)
+    )
+    assert app_handler.when == "MIDNIGHT"
+    assert app_handler.backupCount == 5
+
+    access_handler = next(
+        h for h in access_logger.handlers if isinstance(h, TimedRotatingFileHandler)
+    )
+    assert access_handler.when == "MIDNIGHT"
+    assert access_handler.backupCount == 5
+
+    app_logger.handlers.clear()
+    access_logger.handlers.clear()
+
+
+def test_log_files_and_redaction(log_dir, app_factory):
+    _clear_handlers("app")
+    _clear_handlers("uvicorn.access")
+    app = app_factory(log_dir, log_request_bodies=True)
+
+    app_logger = logging.getLogger("app")
+    app_logger.info("hello app")
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/echo",
+            json={"token": "secret", "value": 1},
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert resp.status_code == 200
+
+    for logger in (app_logger, logging.getLogger("uvicorn.access")):
+        for handler in logger.handlers:
+            handler.flush()
+
+    app_log = log_dir / "app.log"
+    access_log = log_dir / "access.log"
+
+    assert app_log.exists() and app_log.read_text().strip()
+    assert "hello app" in app_log.read_text()
+
+    assert access_log.exists() and access_log.read_text().strip()
+    access_line = access_log.read_text().splitlines()[-1]
+    payload = access_line.split(": ", 1)[1]
+    data = json.loads(payload)
+    assert data["headers"]["authorization"] == "***"
+    assert data["body"]["token"] == "***"
+
+    app_logger.handlers.clear()
+    logging.getLogger("uvicorn.access").handlers.clear()


### PR DESCRIPTION
## Summary
- add app_factory fixture to build FastAPI app with logging
- verify TimedRotatingFileHandler setup and log file creation with redaction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e84f5fe0832393c9447bf92673bb