### PR TITLE
Handle error events in chat stream

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,13 +8,23 @@ import ErrorBanner from './components/ErrorBanner';
 import { useChat } from './chat';
 
 function App() {
-  const { messages, notices, send, isStreaming, cancel, error, clearError } =
-    useChat();
+  const {
+    messages,
+    notices,
+    send,
+    isStreaming,
+    cancel,
+    error,
+    clearError,
+    retry,
+  } = useChat();
 
   return (
     <div className="app">
       <Header />
-      {error && <ErrorBanner message={error} onClose={clearError} />}
+      {error && (
+        <ErrorBanner message={error} onClose={clearError} onRetry={retry} />
+      )}
       <ConversationPane messages={messages} />
       <SystemNotices notices={notices} />
       <Composer onSend={send} onCancel={cancel} isStreaming={isStreaming} />

--- a/frontend/src/components/ErrorBanner.tsx
+++ b/frontend/src/components/ErrorBanner.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 interface Props {
   message: string;
   onClose: () => void;
+  onRetry?: () => void;
 }
 
-export default function ErrorBanner({ message, onClose }: Props) {
+export default function ErrorBanner({ message, onClose, onRetry }: Props) {
   return (
     <div className="error-banner">
       <span>{message}</span>
+      {onRetry && <button onClick={onRetry}>Tentar novamente</button>}
       <button onClick={onClose}>Fechar</button>
     </div>
   );


### PR DESCRIPTION
## Summary
- handle `error` events in chat stream and mark responses complete
- expose `retry` function and add retry button in error banner

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f2cc95b88323945c48d97c89609a