### PR TITLE
Enforce message length limits in chat composer

### DIFF
--- a/frontend/src/chat.tsx
+++ b/frontend/src/chat.tsx
@@ -52,6 +52,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   }, [messages]);
 
   const send = async (text: string, file?: File | null) => {
+    if (text.length > 5000) {
+      setError('Mensagem muito longa');
+      return;
+    }
     lastRequestRef.current = { text, file };
     setMessages((msgs) => [
       ...msgs,

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -37,6 +37,7 @@ export default function Composer({ onSend, onCancel, isStreaming }: Props) {
         onChange={(e) => setInput(e.target.value)}
         placeholder="Pergunte algo"
         onKeyDown={handleKeyDown}
+        maxLength={5000}
       />
       <label htmlFor="composer-file">Arquivo PDF</label>
       <input


### PR DESCRIPTION
## Summary
- Abort sending and show error when messages exceed 5000 characters
- Limit composer textarea to 5000 characters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4f9d494e083238d44316f817b21cb