### PR TITLE
feat: enforce upload size limit

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -118,6 +118,7 @@ async def config():
             "POWERED_BY_LABEL", "Powered by PDF Knowledge Kit"
         ),
         "LOGO_URL": os.getenv("LOGO_URL", ""),
+        "UPLOAD_MAX_SIZE": UPLOAD_MAX_SIZE,
     }
 
 

--- a/frontend/src/chat.test.tsx
+++ b/frontend/src/chat.test.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { ChatProvider, useChat } from './chat';
+import { ConfigProvider } from './config';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import 'whatwg-fetch';
 import { vi, beforeAll, afterEach, afterAll, test, expect } from 'vitest';
 
-const server = setupServer();
+const server = setupServer(
+  http.get('/api/config', () =>
+    HttpResponse.json({ UPLOAD_MAX_SIZE: 5 * 1024 * 1024 })
+  )
+);
 
 beforeAll(() => server.listen());
 afterEach(() => {
@@ -17,7 +22,11 @@ afterAll(() => server.close());
 
 function renderChat() {
   return renderHook(() => useChat(), {
-    wrapper: ({ children }) => <ChatProvider>{children}</ChatProvider>,
+    wrapper: ({ children }) => (
+      <ConfigProvider>
+        <ChatProvider>{children}</ChatProvider>
+      </ConfigProvider>
+    ),
   });
 }
 
@@ -83,13 +92,58 @@ test('upload errors surface', async () => {
   });
 });
 
+test('SSE error event stops streaming and shows message', async () => {
+  server.use(
+    http.post('/api/chat', () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('event: error\ndata: boom\n\n'));
+          controller.close();
+        },
+      });
+      return new HttpResponse(stream, {
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    })
+  );
+  const { result } = renderChat();
+  await act(async () => {
+    await result.current.send('Hi');
+  });
+  await waitFor(() => {
+    expect(result.current.error).toBe('boom');
+    expect(result.current.messages[1].status).toBe('done');
+  });
+});
+
 test('oversized client messages trigger validation without network calls', async () => {
   const fetchSpy = vi.spyOn(global, 'fetch');
   const { result } = renderChat();
+  await waitFor(() => fetchSpy.mock.calls.length > 0).catch(() => {});
+  fetchSpy.mockClear();
   await act(async () => {
     await result.current.send('a'.repeat(5001));
   });
   expect(fetchSpy).not.toHaveBeenCalled();
   expect(result.current.error).toBe('Mensagem muito longa');
+  fetchSpy.mockRestore();
+});
+
+test('oversized file triggers local validation without network calls', async () => {
+  const fetchSpy = vi.spyOn(global, 'fetch');
+  const { result } = renderChat();
+  await waitFor(() => fetchSpy.mock.calls.length > 0).catch(() => {});
+  fetchSpy.mockClear();
+  const hugeFile = new File(
+    [new Uint8Array(5 * 1024 * 1024 + 1)],
+    'huge.pdf',
+    { type: 'application/pdf' }
+  );
+  await act(async () => {
+    await result.current.send('Hi', hugeFile);
+  });
+  expect(fetchSpy).not.toHaveBeenCalled();
+  expect(result.current.error).toBe('Arquivo muito grande');
   fetchSpy.mockRestore();
 });

--- a/frontend/src/chat.tsx
+++ b/frontend/src/chat.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useConfig } from './config';
 
 export interface Message {
   role: 'user' | 'assistant';
@@ -37,6 +38,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const [error, setError] = useState<string | null>(null);
   const controllerRef = useRef<AbortController | null>(null);
   const lastRequestRef = useRef<{ text: string; file?: File | null } | null>(null);
+  const { UPLOAD_MAX_SIZE } = useConfig();
 
   useEffect(() => {
     let id = localStorage.getItem('sessionId');
@@ -54,6 +56,10 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   const send = async (text: string, file?: File | null) => {
     if (text.length > 5000) {
       setError('Mensagem muito longa');
+      return;
+    }
+    if (file && file.size > UPLOAD_MAX_SIZE) {
+      setError('Arquivo muito grande');
       return;
     }
     lastRequestRef.current = { text, file };

--- a/frontend/src/config.tsx
+++ b/frontend/src/config.tsx
@@ -4,12 +4,14 @@ export interface AppConfig {
   BRAND_NAME: string;
   POWERED_BY_LABEL: string;
   LOGO_URL: string;
+  UPLOAD_MAX_SIZE: number;
 }
 
 const defaultConfig: AppConfig = {
   BRAND_NAME: 'PDF Knowledge Kit',
   POWERED_BY_LABEL: 'Powered by PDF Knowledge Kit',
   LOGO_URL: '',
+  UPLOAD_MAX_SIZE: 5 * 1024 * 1024,
 };
 
 const ConfigContext = createContext<AppConfig>(defaultConfig);


### PR DESCRIPTION
## Summary
- expose `UPLOAD_MAX_SIZE` via `/api/config`
- read max upload size in config provider and chat module
- reject oversize attachments client-side with "Arquivo muito grande" message and tests
- add SSE error event test ensuring chat context captures errors and finalizes assistant message

## Testing
- `pytest`
- `npx vitest run src/chat.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a4ec06d364832385981fc825894ea2