### PR TITLE
Add CI workflow for ingest URL tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Run tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run ingest URL tests
+        run: |
+          pytest tests/test_ingest_url.py


### PR DESCRIPTION
## Summary
- run pytest against tests/test_ingest_url.py in GitHub Actions
- ensure CI installs dependencies from requirements.txt

## Testing
- `pytest tests/test_ingest_url.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5871227548323a79e3ab3573ecd4b