### PR TITLE
Add admin ingestion tables and storage helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ pdf_knowledge_kit/
 ├─ docker-compose.yml      # Postgres + pgvector
 ├─ requirements.txt        # Dependências
 ├─ schema.sql              # Criação de tabelas/índices
+├─ migrations/             # Migrações incrementais do banco de dados
 ├─ ingest.py               # Varre PDFs/Markdown, extrai, fatia e insere
 ├─ query.py                # Busca semântica
 ├─ .env.example            # Configs de conexão
@@ -284,6 +285,7 @@ pdf_knowledge_kit/
 ```bash
 psql -c 'CREATE EXTENSION IF NOT EXISTS vector;' "$PGDATABASE"
 psql -f schema.sql "$PGDATABASE"
+psql -f migrations/002_add_admin_ingestion.sql "$PGDATABASE"
 ```
 2. Configure as variáveis de ambiente (veja `.env.example`).
 3. Ingestione os documentos:

--- a/app/ingestion/storage.py
+++ b/app/ingestion/storage.py
@@ -9,36 +9,58 @@ import psycopg
 from .models import IngestionJob, IngestionJobStatus, Source, SourceType
 
 
-def create_source(conn: psycopg.Connection, *, type: SourceType, path: str | None = None, url: str | None = None) -> UUID:
-    source_id = uuid4()
+def get_or_create_source(
+    conn: psycopg.Connection,
+    *,
+    type: SourceType,
+    path: str | None = None,
+    url: str | None = None,
+) -> UUID:
+    """Fetch an existing source or create a new record.
+
+    A source is considered unique by its ``path`` or ``url``. Soft deleted
+    sources are ignored when checking for existing records.
+    """
+
     with conn.cursor() as cur:
+        # Try to find an existing source first.
+        if path is not None:
+            cur.execute(
+                "SELECT id FROM sources WHERE path = %s AND deleted_at IS NULL",
+                (path,),
+            )
+            row = cur.fetchone()
+            if row:
+                return row[0]
+
+        if url is not None:
+            cur.execute(
+                "SELECT id FROM sources WHERE url = %s AND deleted_at IS NULL",
+                (url,),
+            )
+            row = cur.fetchone()
+            if row:
+                return row[0]
+
+        # No existing source found; create one.
+        source_id = uuid4()
         cur.execute(
             "INSERT INTO sources (id, type, path, url, created_at) VALUES (%s, %s, %s, %s, now())",
             (source_id, type.value, path, url),
         )
+
     conn.commit()
     return source_id
 
 
-def get_source(conn: psycopg.Connection, source_id: UUID) -> Optional[Source]:
-    with conn.cursor() as cur:
-        cur.execute("SELECT id, type, path, url, created_at FROM sources WHERE id = %s", (source_id,))
-        row = cur.fetchone()
-    if not row:
-        return None
-    return Source(
-        id=row[0],
-        type=SourceType(row[1]),
-        path=row[2],
-        url=row[3],
-        created_at=row[4],
-    )
-
-
 def list_sources(conn: psycopg.Connection) -> Iterable[Source]:
+    """Return active (non-deleted) sources ordered by creation date."""
     with conn.cursor() as cur:
-        cur.execute("SELECT id, type, path, url, created_at FROM sources ORDER BY created_at DESC")
+        cur.execute(
+            "SELECT id, type, path, url, created_at FROM sources WHERE deleted_at IS NULL ORDER BY created_at DESC"
+        )
         rows = cur.fetchall()
+
     for row in rows:
         yield Source(
             id=row[0],
@@ -105,3 +127,41 @@ def list_jobs(conn: psycopg.Connection) -> Iterable[IngestionJob]:
             updated_at=row[4],
             error=row[5],
         )
+
+
+def update_source(
+    conn: psycopg.Connection,
+    source_id: UUID,
+    *,
+    path: str | None = None,
+    url: str | None = None,
+) -> None:
+    """Update a source's path or URL."""
+
+    fields: list[str] = []
+    values: list[str] = []
+    if path is not None:
+        fields.append("path = %s")
+        values.append(path)
+    if url is not None:
+        fields.append("url = %s")
+        values.append(url)
+    if not fields:
+        return
+
+    values.append(source_id)
+    sql = f"UPDATE sources SET {', '.join(fields)}, updated_at = now() WHERE id = %s"
+    with conn.cursor() as cur:
+        cur.execute(sql, values)
+    conn.commit()
+
+
+def soft_delete_source(conn: psycopg.Connection, source_id: UUID) -> None:
+    """Soft delete a source by marking its ``deleted_at`` timestamp."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE sources SET deleted_at = now(), updated_at = now() WHERE id = %s",
+            (source_id,),
+        )
+    conn.commit()

--- a/migrations/002_add_admin_ingestion.sql
+++ b/migrations/002_add_admin_ingestion.sql
@@ -1,0 +1,31 @@
+-- Enable pgcrypto for gen_random_uuid
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Table to track content sources for ingestion
+CREATE TABLE IF NOT EXISTS sources (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    type TEXT NOT NULL,
+    path TEXT,
+    url TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ
+);
+
+-- Ensure fast lookups and uniqueness
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sources_path ON sources (path) WHERE path IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sources_url ON sources (url) WHERE url IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sources_created_at ON sources (created_at);
+
+-- Table to register ingestion jobs
+CREATE TABLE IF NOT EXISTS ingestion_jobs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_id UUID NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+    status TEXT NOT NULL,
+    error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_jobs_source ON ingestion_jobs (source_id);
+CREATE INDEX IF NOT EXISTS idx_ingestion_jobs_created_at ON ingestion_jobs (created_at);


### PR DESCRIPTION
## Summary
- add migration creating `sources` and `ingestion_jobs` tables with indexes
- run migrations after base schema during DB bootstrap
- implement storage helpers for managing sources and ingestion jobs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d34f24f48323bfe6abc492718c79