### PR TITLE
Refactor ingest CLI to use service module

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -1,10 +1,110 @@
-"""Compatibility module for legacy imports.
+"""CLI wrapper for :mod:`app.ingestion.service`.
 
-This file simply aliases :mod:`app.ingestion.service` so existing imports of
-``ingest`` continue to work. Any attribute set on this module actually modifies
-``app.ingestion.service``.
+This module preserves the old ``ingest.py`` command line interface while
+delegating all functionality to :mod:`app.ingestion.service`.  When imported
+as ``ingest`` it simply re-exports the service module for backward
+compatibility.  When executed as a script it parses the legacy CLI arguments
+and forwards the work to the new service functions.
 """
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
 import sys
+import uuid
+from pathlib import Path
+
 from app.ingestion import service as _service
 
-sys.modules[__name__] = _service
+
+def _iter_docs(doc_path: Path) -> list[Path]:
+    """Yield Markdown and PDF files from ``doc_path`` recursively."""
+
+    exts = {".pdf", ".md"}
+    if doc_path.is_file() and doc_path.suffix.lower() in exts:
+        return [doc_path]
+    files: list[Path] = []
+    for p in sorted(doc_path.rglob("*")):
+        if p.is_file() and p.suffix.lower() in exts:
+            files.append(p)
+    return files
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Parse CLI arguments and execute the requested ingestion tasks."""
+
+    parser = argparse.ArgumentParser(description="Ingest documents and URLs")
+    parser.add_argument(
+        "--docs",
+        default=os.getenv("DOCS_DIR"),
+        help="Directory containing PDFs/Markdown files",
+    )
+    parser.add_argument(
+        "--url",
+        dest="urls",
+        action="append",
+        default=[],
+        help="URL to ingest (may be specified multiple times)",
+    )
+    parser.add_argument(
+        "--urls-file",
+        default=os.getenv("URLS_FILE"),
+        help="File with URLs to ingest, one per line",
+    )
+    parser.add_argument(
+        "--reindex",
+        help="Reindex an existing source by UUID",
+    )
+    parser.add_argument(
+        "--ocr",
+        action="store_true",
+        default=os.getenv("ENABLE_OCR") == "1",
+        help="Enable OCR for PDFs without embedded text",
+    )
+    parser.add_argument(
+        "--ocr-lang",
+        default=os.getenv("OCR_LANG"),
+        help="Languages for Tesseract OCR (e.g., eng+por)",
+    )
+
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    log = logging.getLogger("ingest")
+
+    if args.docs:
+        doc_dir = Path(args.docs)
+        for doc in _iter_docs(doc_dir):
+            log.info("ingesting %s", doc)
+            _service.ingest_local(doc, use_ocr=args.ocr, ocr_lang=args.ocr_lang)
+
+    urls: list[str] = list(args.urls)
+    if args.urls_file:
+        path = Path(args.urls_file)
+        if path.exists():
+            with path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        urls.append(line)
+    if urls:
+        log.info("ingesting %d url(s)", len(urls))
+        _service.ingest_urls(urls)
+
+    if args.reindex:
+        try:
+            source_id = uuid.UUID(args.reindex)
+        except ValueError:
+            log.error("--reindex requires a valid UUID")
+        else:
+            _service.reindex_source(source_id)
+
+
+if __name__ != "__main__":  # pragma: no cover - import-time aliasing
+    # When imported, expose the service module directly for compatibility.
+    sys.modules[__name__] = _service
+else:  # pragma: no cover - CLI execution
+    main()
+

--- a/tests/test_ingest_md.py
+++ b/tests/test_ingest_md.py
@@ -1,5 +1,5 @@
 import pathlib
-import ingest
+from app.ingestion import service as ingest
 
 
 class DummyEmbedder:

--- a/tests/test_ingest_ocr.py
+++ b/tests/test_ingest_ocr.py
@@ -4,7 +4,7 @@ from pypdf import PdfWriter
 pytest.importorskip("pytesseract")
 pytest.importorskip("pdf2image")
 
-import ingest
+from app.ingestion import service as ingest
 
 
 @pytest.fixture(params=["eng", "por", "spa"])

--- a/tests/test_ingest_url.py
+++ b/tests/test_ingest_url.py
@@ -1,4 +1,4 @@
-import ingest
+from app.ingestion import service as ingest
 import pytest
 
 


### PR DESCRIPTION
## Summary
- Rewrite legacy `ingest.py` as a CLI wrapper around `app.ingestion.service`
- Support original CLI flags (`--docs`, `--url`, `--urls-file`, `--reindex`, `--ocr`, `--ocr-lang`) via service functions
- Update tests to import helpers from `app.ingestion.service`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d9cb2c1483238dcc6283fdbaf623