### PR TITLE
docs: document admin ingest API and env keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,8 @@ LOG_REQUEST_BODIES=false
 # OCR (opcional)
 # ENABLE_OCR=1
 # OCR_LANG=eng+por+spa
+
+# Chaves para API de ingestão administrativa (/api/admin/ingest)
+ADMIN_API_KEYS=admin
+OPERATOR_API_KEYS=oper
+VIEWER_API_KEYS=view


### PR DESCRIPTION
## Summary
- document role-based `/api/admin/ingest` endpoints with curl samples, job lifecycle, and minimal admin UI instructions
- add ADMIN_API_KEYS, OPERATOR_API_KEYS, and VIEWER_API_KEYS to example environment file
- clarify env var names and curl examples for admin ingest API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5dfc440708323b01e160ea7014827