### PR TITLE
Expand ingestion and admin API test coverage

### DIFF
--- a/tests/test_admin_ingest_api_extended.py
+++ b/tests/test_admin_ingest_api_extended.py
@@ -1,0 +1,209 @@
+import importlib
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.ingestion.models import IngestionJob, IngestionJobStatus, Source, SourceType
+
+
+def create_client(monkeypatch):
+    monkeypatch.setenv("VIEWER_API_KEYS", "view")
+    monkeypatch.setenv("OPERATOR_API_KEYS", "oper")
+    monkeypatch.setenv("ADMIN_API_KEYS", "admin")
+    import app.security.auth as auth
+    importlib.reload(auth)
+    import app.routers.admin_ingest_api as admin_api
+    importlib.reload(admin_api)
+    import app.main as main
+    importlib.reload(main)
+    return TestClient(main.app), admin_api
+
+
+def test_start_local_job_auth_validation(monkeypatch):
+    client, admin_api = create_client(monkeypatch)
+    dummy_id = uuid4()
+    monkeypatch.setattr(admin_api.service, "ingest_local", lambda *a, **k: dummy_id)
+
+    # missing key
+    res = client.post("/api/admin/ingest/jobs/local", params={"path": "/tmp/a"})
+    assert res.status_code == 401
+
+    # viewer forbidden
+    res = client.post(
+        "/api/admin/ingest/jobs/local",
+        params={"path": "/tmp/a"},
+        headers={"X-API-Key": "view"},
+    )
+    assert res.status_code == 403
+
+    # validation error missing path
+    res = client.post("/api/admin/ingest/jobs/local", headers={"X-API-Key": "oper"})
+    assert res.status_code == 422
+
+    # operator success
+    res = client.post(
+        "/api/admin/ingest/jobs/local",
+        params={"path": "/tmp/a"},
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+    assert res.json()["job_id"] == str(dummy_id)
+
+
+def test_start_urls_job_validation(monkeypatch):
+    client, admin_api = create_client(monkeypatch)
+    dummy_id = uuid4()
+    monkeypatch.setattr(admin_api.service, "ingest_urls", lambda urls: dummy_id)
+
+    # validation error for body
+    res = client.post("/api/admin/ingest/jobs/urls", headers={"X-API-Key": "oper"})
+    assert res.status_code == 422
+
+    res = client.post(
+        "/api/admin/ingest/jobs/urls",
+        json=["http://a"],
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+    assert res.json()["job_id"] == str(dummy_id)
+
+
+def test_sources_crud_and_reindex(monkeypatch):
+    client, admin_api = create_client(monkeypatch)
+    sources: dict[UUID, Source] = {}
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(admin_api, "_get_conn", lambda: DummyConn())
+
+    def get_or_create(conn, type, path=None, url=None):
+        sid = uuid4()
+        sources[sid] = Source(id=sid, type=type, path=path, url=url, created_at=datetime.utcnow())
+        return sid
+    monkeypatch.setattr(admin_api.storage, "get_or_create_source", get_or_create)
+    monkeypatch.setattr(admin_api.storage, "list_sources", lambda conn: sources.values())
+    def update(conn, sid, path=None, url=None):
+        src = sources[sid]
+        if path:
+            src.path = path
+        if url:
+            src.url = url
+    monkeypatch.setattr(admin_api.storage, "update_source", update)
+    monkeypatch.setattr(admin_api.storage, "soft_delete_source", lambda conn, sid: sources.pop(sid, None))
+    called = {}
+    monkeypatch.setattr(admin_api.service, "reindex_source", lambda sid: called.setdefault("rid", sid))
+
+    # create
+    res = client.post(
+        "/api/admin/ingest/sources",
+        params={"type": "local", "path": "/a"},
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+    sid = UUID(res.json()["source_id"])
+
+    # list
+    res = client.get("/api/admin/ingest/sources", headers={"X-API-Key": "view"})
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+
+    # update
+    res = client.put(
+        f"/api/admin/ingest/sources/{sid}",
+        params={"path": "/b"},
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+
+    # reindex
+    res = client.post(
+        f"/api/admin/ingest/sources/{sid}/reindex",
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+    assert called["rid"] == sid
+
+    # delete
+    res = client.delete(
+        f"/api/admin/ingest/sources/{sid}",
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+
+    res = client.get("/api/admin/ingest/sources", headers={"X-API-Key": "view"})
+    assert res.status_code == 200
+    assert res.json() == []
+
+
+def test_job_lifecycle_and_logs(monkeypatch):
+    client, admin_api = create_client(monkeypatch)
+    jobs: dict[UUID, IngestionJob] = {}
+    log_states = ["", "line1\n", "line1\nline2\n"]
+    call = {"i": 0}
+
+    def ingest_url(url):
+        job_id = uuid4()
+        jobs[job_id] = IngestionJob(
+            id=job_id,
+            source_id=uuid4(),
+            status=IngestionJobStatus.PENDING,
+            created_at=datetime.utcnow(),
+        )
+        return job_id
+
+    def list_jobs():
+        return list(jobs.values())
+
+    def cancel_job(job_id):
+        jobs[job_id].status = IngestionJobStatus.CANCELED
+
+    def get_job(job_id):
+        status = IngestionJobStatus.RUNNING if call["i"] < 2 else IngestionJobStatus.COMPLETED
+        return IngestionJob(id=job_id, source_id=uuid4(), status=status, created_at=datetime.utcnow())
+
+    def read_job_log(job_id):
+        i = call["i"]
+        call["i"] = min(i + 1, len(log_states) - 1)
+        return log_states[i]
+
+    async def fake_sleep(_):
+        return None
+
+    monkeypatch.setattr(admin_api.service, "ingest_url", ingest_url)
+    monkeypatch.setattr(admin_api.service, "list_jobs", list_jobs)
+    monkeypatch.setattr(admin_api.service, "cancel_job", cancel_job)
+    monkeypatch.setattr(admin_api.service, "get_job", get_job)
+    monkeypatch.setattr(admin_api.service, "read_job_log", read_job_log)
+    monkeypatch.setattr(admin_api.asyncio, "sleep", fake_sleep)
+
+    res = client.post(
+        "/api/admin/ingest/jobs/url",
+        params={"url": "http://example.com"},
+        headers={"X-API-Key": "oper"},
+    )
+    job_id = UUID(res.json()["job_id"])
+
+    res = client.get("/api/admin/ingest/jobs", headers={"X-API-Key": "view"})
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+
+    res = client.post(
+        f"/api/admin/ingest/jobs/{job_id}/cancel",
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+    assert jobs[job_id].status == IngestionJobStatus.CANCELED
+
+    with client.stream(
+        "GET", f"/api/admin/ingest/jobs/{job_id}/logs", headers={"X-API-Key": "view"}
+    ) as res:
+        raw = list(res.iter_lines())
+    lines = [l.decode() if isinstance(l, bytes) else l for l in raw]
+    assert any("line1" in l for l in lines)
+    assert any("event: end" in l for l in lines)

--- a/tests/test_ingest_md.py
+++ b/tests/test_ingest_md.py
@@ -1,5 +1,5 @@
 import pathlib
-from app.ingestion import service as ingest
+import app.ingestion.service as ingest
 
 
 class DummyEmbedder:

--- a/tests/test_ingest_ocr.py
+++ b/tests/test_ingest_ocr.py
@@ -4,7 +4,7 @@ from pypdf import PdfWriter
 pytest.importorskip("pytesseract")
 pytest.importorskip("pdf2image")
 
-from app.ingestion import service as ingest
+import app.ingestion.service as ingest
 
 
 @pytest.fixture(params=["eng", "por", "spa"])

--- a/tests/test_ingest_url.py
+++ b/tests/test_ingest_url.py
@@ -1,4 +1,4 @@
-from app.ingestion import service as ingest
+import app.ingestion.service as ingest
 import pytest
 
 

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -1,0 +1,37 @@
+import app.ingestion.service as service
+from app.ingestion.runner import IngestionRunner
+from uuid import uuid4
+from threading import Event
+import time
+import pathlib
+
+
+def test_runner_cancel_stops_work():
+    runner = IngestionRunner(max_workers=1)
+    job_id = uuid4()
+    events = {}
+
+    def work(ev: Event):
+        events['evt'] = ev
+        while not ev.is_set():
+            time.sleep(0.01)
+
+    fut = runner.submit(job_id, work)
+    runner.cancel(job_id)
+    # give thread time to process cancellation
+    time.sleep(0.05)
+    assert events['evt'].is_set()
+    assert fut.cancelled() or fut.done()
+
+
+def test_setup_job_logging_creates_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    job_id = uuid4()
+    logger = service._setup_job_logging(job_id)
+    logger.info("hello")
+    for h in list(logger.handlers):
+        h.close()
+        logger.removeHandler(h)
+    log_path = pathlib.Path("logs") / "jobs" / f"{job_id}.log"
+    assert log_path.exists()
+    assert "hello" in log_path.read_text(encoding="utf-8")

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -1,0 +1,53 @@
+import pathlib
+from threading import Event
+from uuid import uuid4
+
+import pytest
+
+import app.ingestion.service as service
+from app.ingestion.models import IngestionJobStatus
+
+
+class ImmediateRunner:
+    def submit(self, job_id, fn):
+        ev = Event()
+        fn(ev)
+        class DummyFuture:
+            def cancel(self):
+                return False
+        return DummyFuture()
+
+
+def test_ingest_local_and_url(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(service, "_runner", ImmediateRunner())
+    path = tmp_path / "doc.md"
+    path.write_text("hello", encoding="utf-8")
+    job_id = service.ingest_local(path)
+    job = service.get_job(job_id)
+    assert job.status == IngestionJobStatus.COMPLETED
+    log_path = pathlib.Path("logs") / "jobs" / f"{job_id}.log"
+    assert log_path.exists()
+
+    monkeypatch.setattr(service, "read_url_text", lambda url: "hi")
+    job_id2 = service.ingest_url("http://example.com")
+    job2 = service.get_job(job_id2)
+    assert job2.status == IngestionJobStatus.COMPLETED
+
+
+def test_ingest_local_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(service, "_runner", ImmediateRunner())
+    path = tmp_path / "bad.md"
+    path.write_text("boom", encoding="utf-8")
+    def bad(_):
+        raise ValueError("fail")
+    monkeypatch.setattr(service, "read_md_text", bad)
+    job_id = service.ingest_local(path)
+    job = service.get_job(job_id)
+    assert job.status == IngestionJobStatus.FAILED
+    assert job.error
+
+
+def test_reindex_source_noop():
+    assert service.reindex_source(uuid4()) is None

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from app.ingestion import service, storage
+from app.ingestion.models import IngestionJobStatus, SourceType
+
+
+def _require_conn():
+    url = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
+    try:
+        return psycopg.connect(url)
+    except Exception:
+        pytest.skip("database not available")
+
+
+def test_migration_persistence_and_soft_delete(tmp_path):
+    conn = _require_conn()
+    service.ensure_schema(conn, Path("schema.sql"), Path("migrations"))
+    src_id = storage.get_or_create_source(conn, type=SourceType.LOCAL, path=str(tmp_path / "a"))
+    job_id = storage.create_job(conn, src_id)
+    job = storage.get_job(conn, job_id)
+    assert job and job.status == IngestionJobStatus.PENDING
+    storage.soft_delete_source(conn, src_id)
+    assert list(storage.list_sources(conn)) == []
+    conn.close()


### PR DESCRIPTION
## Summary
- standardize ingestion tests to import from `app.ingestion.service`
- add unit tests for ingestion runner cancellation and job logging
- cover ingestion service flows and error handling
- expand admin ingest API tests for auth, validation, lifecycle, and logs
- verify migrations for sources and ingestion jobs including soft-delete

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f4895f1883239baef169ab162b3a