### PR TITLE
feat: add log slicing endpoint

### DIFF
--- a/app/ingestion/models.py
+++ b/app/ingestion/models.py
@@ -41,3 +41,24 @@ class IngestionJob(BaseModel):
     created_at: datetime
     updated_at: Optional[datetime] = None
     error: Optional[str] = None
+
+
+class JobLogSlice(BaseModel):
+    """A slice of a job log file.
+
+    Attributes
+    ----------
+    text:
+        The log content read starting at ``offset``.
+    next_offset:
+        Byte offset for the next read.
+    total:
+        Total size of the log file in bytes.
+    status:
+        Final status of the job if it has completed, otherwise ``None``.
+    """
+
+    text: str
+    next_offset: int
+    total: int
+    status: Optional[IngestionJobStatus] = None


### PR DESCRIPTION
## Summary
- add JobLogSlice model and log reader that supports offsets
- expose job log slices via `/api/admin/ingest/jobs/{job_id}/logs`
- poll job logs from admin frontend for real-time updates

## Testing
- `pytest -q`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a5f77226508323970e693148f8ae37