### PR TITLE
Refactor ingestion models and job enums

### DIFF
--- a/app/routers/admin_ingest_api.py
+++ b/app/routers/admin_ingest_api.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import psycopg
 from fastapi import APIRouter, Body, Depends, HTTPException
 from ..ingestion import service, storage
-from ..ingestion.models import IngestionJobStatus, SourceType, JobLogSlice
+from ..ingestion.models import JobStatus, SourceType, JobLogSlice
 from ..security.auth import require_role
 
 router = APIRouter(prefix="/api/admin/ingest", tags=["admin-ingest"])

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,7 +5,7 @@ import psycopg
 import pytest
 
 from app.ingestion import service, storage
-from app.ingestion.models import IngestionJobStatus, SourceType
+from app.ingestion.models import JobStatus, SourceType
 
 
 def _require_conn():
@@ -19,10 +19,10 @@ def _require_conn():
 def test_migration_persistence_and_soft_delete(tmp_path):
     conn = _require_conn()
     service.ensure_schema(conn, Path("schema.sql"), Path("migrations"))
-    src_id = storage.get_or_create_source(conn, type=SourceType.LOCAL, path=str(tmp_path / "a"))
+    src_id = storage.get_or_create_source(conn, type=SourceType.LOCAL_DIR, path=str(tmp_path / "a"))
     job_id = storage.create_job(conn, src_id)
     job = storage.get_job(conn, job_id)
-    assert job and job.status == IngestionJobStatus.PENDING
+    assert job and job.status == JobStatus.QUEUED
     storage.soft_delete_source(conn, src_id)
     assert list(storage.list_sources(conn)) == []
     conn.close()


### PR DESCRIPTION
## Summary
- revamp ingestion models with detailed request and response schemas
- rename enums to `JobStatus` and `SourceType` with new values
- update services, storage, and tests to use new models and job log structure

## Testing
- `pytest tests/test_admin_ingest_api_extended.py tests/test_ingestion_service.py tests/test_migrations.py -q` *(fails: connection to Postgres refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a601adb6208323806d54c5f50dad8f