### PR TITLE
feat: update admin frontend for JSON API and logs

### DIFF
--- a/frontend/src/admin/IngestLocal.tsx
+++ b/frontend/src/admin/IngestLocal.tsx
@@ -8,12 +8,16 @@ export default function IngestLocal() {
   const [lang, setLang] = useState('');
   const [jobId, setJobId] = useState<string | null>(null);
 
+  interface StartJobResponse { job_id: string }
+
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    const params = new URLSearchParams({ path, use_ocr: String(useOcr) });
-    if (lang) params.append('ocr_lang', lang);
-    apiFetch(`/api/admin/ingest/jobs/local?${params.toString()}`, { method: 'POST' })
-      .then((r) => r.json())
+    apiFetch('/api/admin/ingest/local', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path, use_ocr: useOcr, ocr_lang: lang || undefined }),
+    })
+      .then((r) => r.json() as Promise<StartJobResponse>)
       .then((d) => setJobId(d.job_id))
       .catch(() => {});
   };

--- a/frontend/src/admin/IngestUrl.tsx
+++ b/frontend/src/admin/IngestUrl.tsx
@@ -6,11 +6,16 @@ export default function IngestUrl() {
   const [url, setUrl] = useState('');
   const [jobId, setJobId] = useState<string | null>(null);
 
+  interface StartJobResponse { job_id: string }
+
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    const params = new URLSearchParams({ url });
-    apiFetch(`/api/admin/ingest/jobs/url?${params.toString()}`, { method: 'POST' })
-      .then((r) => r.json())
+    apiFetch('/api/admin/ingest/url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    })
+      .then((r) => r.json() as Promise<StartJobResponse>)
       .then((d) => setJobId(d.job_id))
       .catch(() => {});
   };

--- a/frontend/src/admin/IngestUrls.tsx
+++ b/frontend/src/admin/IngestUrls.tsx
@@ -14,12 +14,13 @@ export default function IngestUrls() {
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    apiFetch('/api/admin/ingest/jobs/urls', {
+    interface StartJobResponse { job_id: string }
+    apiFetch('/api/admin/ingest/urls', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(urls.filter((u) => u)),
+      body: JSON.stringify({ urls: urls.filter((u) => u) }),
     })
-      .then((r) => r.json())
+      .then((r) => r.json() as Promise<StartJobResponse>)
       .then((d) => setJobId(d.job_id))
       .catch(() => {});
   };
@@ -40,7 +41,7 @@ export default function IngestUrls() {
             />
           </div>
         ))}
-        <button type="button" onClick={addField}>Add URL</button>
+        <button type="button" onClick={addField} aria-label="Add another URL">Add URL</button>
         <button type="submit">Start</button>
       </form>
       {jobId && <p>Started job {jobId}</p>}

--- a/frontend/src/admin/JobDetail.tsx
+++ b/frontend/src/admin/JobDetail.tsx
@@ -1,38 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useApiFetch } from '../apiKey';
+import LogViewer from './LogViewer';
 
 export default function JobDetail() {
   const { id } = useParams<{ id: string }>();
   const apiFetch = useApiFetch();
-  const [log, setLog] = useState('');
   const [status, setStatus] = useState('');
-
-  useEffect(() => {
-    let canceled = false;
-    let offset = 0;
-    async function poll() {
-      while (!canceled) {
-        const res = await apiFetch(
-          `/api/admin/ingest/jobs/${id}/logs?offset=${offset}`,
-        );
-        const data = await res.json();
-        if (data.text) {
-          setLog((prev) => prev + data.text);
-        }
-        offset = data.next_offset;
-        if (data.status) {
-          setStatus(data.status);
-          break;
-        }
-        await new Promise((r) => setTimeout(r, 500));
-      }
-    }
-    poll();
-    return () => {
-      canceled = true;
-    };
-  }, [id, apiFetch]);
 
   const cancelJob = () => {
     if (window.confirm('Cancel job?')) {
@@ -45,15 +19,24 @@ export default function JobDetail() {
   return (
     <div>
       <h2>Job {id}</h2>
-      <pre
-        aria-label="Log output"
-        tabIndex={0}
-        style={{ background: '#fff', color: '#000', padding: '1em', maxHeight: '300px', overflow: 'auto' }}
-      >
-        {log}
-      </pre>
-      <p>Status: {status}</p>
-      <button onClick={cancelJob}>Cancel</button>
+      <LogViewer jobId={id!} onStatus={setStatus} />
+      <div>
+        <button
+          aria-label="Cancel job"
+          onClick={cancelJob}
+          disabled={!!status && status !== 'queued' && status !== 'running'}
+        >
+          Cancel
+        </button>
+        <button
+          aria-label="Re-run job"
+          onClick={() =>
+            apiFetch(`/api/admin/ingest/jobs/${id}/rerun`, { method: 'POST' }).then(() => {})
+          }
+        >
+          Re-run
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/admin/LogViewer.tsx
+++ b/frontend/src/admin/LogViewer.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { useApiFetch } from '../apiKey';
+
+interface LogSlice {
+  content: string;
+  next_offset: number;
+  status?: string | null;
+}
+
+export default function LogViewer({ jobId, onStatus }: { jobId: string; onStatus?: (s: string) => void }) {
+  const apiFetch = useApiFetch();
+  const [log, setLog] = useState('');
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    let canceled = false;
+    let offset = 0;
+    async function poll() {
+      while (!canceled) {
+        const res = await apiFetch(`/api/admin/ingest/jobs/${jobId}/logs?offset=${offset}`);
+        const data: LogSlice = await res.json();
+        if (data.content) {
+          setLog((prev) => prev + data.content);
+        }
+        offset = data.next_offset;
+        if (data.status) {
+          setStatus(data.status);
+          onStatus?.(data.status);
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+    poll();
+    return () => {
+      canceled = true;
+    };
+  }, [jobId, apiFetch, onStatus]);
+
+  return (
+    <div>
+      <pre
+        aria-label="Log output"
+        tabIndex={0}
+        style={{ background: '#fff', color: '#000', padding: '1em', maxHeight: '300px', overflow: 'auto' }}
+      >
+        {log}
+      </pre>
+      {status && <p>Status: {status}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- switch admin ingest forms to JSON endpoints with typed responses
- add reusable LogViewer component and integrate with job detail page
- poll jobs for status and expose cancel/re-run actions with better ARIA labels

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a634134d7083238aec8484310997e7