### PR TITLE
feat: add role-aware auth and UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ from slowapi.middleware import SlowAPIMiddleware
 
 from .rag import build_context
 from .app_logging import init_logging
-from .routers import admin_ingest_api
+from .routers import admin_ingest_api, auth_api
 
 try:
     from openai import OpenAI
@@ -73,6 +73,7 @@ if admin_ui_origins:
     )
 app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR), name="uploads")
 app.include_router(admin_ingest_api.router)
+app.include_router(auth_api.router)
 app.mount(
     "/",
     StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static"), html=True),

--- a/app/routers/auth_api.py
+++ b/app/routers/auth_api.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Depends
+
+from ..security.auth import require_role
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+@router.get("/roles")
+async def get_roles(role: str = Depends(require_role("viewer"))):
+    return {"roles": [role]}

--- a/frontend/src/admin/AdminRoute.tsx
+++ b/frontend/src/admin/AdminRoute.tsx
@@ -4,16 +4,16 @@ import { toast } from 'react-toastify';
 import useAuth from '../hooks/useAuth';
 
 export default function AdminRoute({ children }: { children: JSX.Element }) {
-  const { roles } = useAuth();
+  const { roles, loading } = useAuth();
   const navigate = useNavigate();
-  const isAdmin = roles.includes('admin');
+  const hasAccess = roles.length > 0;
 
   useEffect(() => {
-    if (!isAdmin) {
+    if (!loading && !hasAccess) {
       toast.error('You are not authorized to view this page');
       navigate('/', { replace: true });
     }
-  }, [isAdmin, navigate]);
+  }, [loading, hasAccess, navigate]);
 
-  return isAdmin ? children : null;
+  return !loading && hasAccess ? children : null;
 }

--- a/frontend/src/admin/Dashboard.tsx
+++ b/frontend/src/admin/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useApiFetch } from '../apiKey';
+import useAuth from '../hooks/useAuth';
 
 interface Job {
   id: string;
@@ -14,6 +15,8 @@ interface JobList {
 
 export default function Dashboard() {
   const apiFetch = useApiFetch();
+  const { roles } = useAuth();
+  const canOperate = roles.includes('operator') || roles.includes('admin');
   const [jobs, setJobs] = useState<Job[]>([]);
 
   const load = () => {
@@ -63,6 +66,7 @@ export default function Dashboard() {
                   onClick={() =>
                     apiFetch(`/api/admin/ingest/jobs/${job.id}/cancel`, { method: 'POST' }).then(load)
                   }
+                  disabled={!canOperate}
                 >
                   Cancel
                 </button>
@@ -71,6 +75,7 @@ export default function Dashboard() {
                   onClick={() =>
                     apiFetch(`/api/admin/ingest/jobs/${job.id}/rerun`, { method: 'POST' }).then(load)
                   }
+                  disabled={!canOperate}
                 >
                   Re-run
                 </button>

--- a/frontend/src/admin/IngestLocal.tsx
+++ b/frontend/src/admin/IngestLocal.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 import { useApiFetch } from '../apiKey';
+import useAuth from '../hooks/useAuth';
 
 export default function IngestLocal() {
   const apiFetch = useApiFetch();
+  const { roles } = useAuth();
+  const canOperate = roles.includes('operator') || roles.includes('admin');
   const [path, setPath] = useState('');
   const [useOcr, setUseOcr] = useState(false);
   const [lang, setLang] = useState('');
@@ -21,6 +24,10 @@ export default function IngestLocal() {
       .then((d) => setJobId(d.job_id))
       .catch(() => {});
   };
+
+  if (!canOperate) {
+    return <p>You do not have permission to start ingestion.</p>;
+  }
 
   return (
     <div>

--- a/frontend/src/admin/IngestUrl.tsx
+++ b/frontend/src/admin/IngestUrl.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 import { useApiFetch } from '../apiKey';
+import useAuth from '../hooks/useAuth';
 
 export default function IngestUrl() {
   const apiFetch = useApiFetch();
+  const { roles } = useAuth();
+  const canOperate = roles.includes('operator') || roles.includes('admin');
   const [url, setUrl] = useState('');
   const [jobId, setJobId] = useState<string | null>(null);
 
@@ -19,6 +22,10 @@ export default function IngestUrl() {
       .then((d) => setJobId(d.job_id))
       .catch(() => {});
   };
+
+  if (!canOperate) {
+    return <p>You do not have permission to start ingestion.</p>;
+  }
 
   return (
     <div>

--- a/frontend/src/admin/IngestUrls.tsx
+++ b/frontend/src/admin/IngestUrls.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 import { useApiFetch } from '../apiKey';
+import useAuth from '../hooks/useAuth';
 
 export default function IngestUrls() {
   const apiFetch = useApiFetch();
+  const { roles } = useAuth();
+  const canOperate = roles.includes('operator') || roles.includes('admin');
   const [urls, setUrls] = useState<string[]>(['']);
   const [jobId, setJobId] = useState<string | null>(null);
 
@@ -24,6 +27,10 @@ export default function IngestUrls() {
       .then((d) => setJobId(d.job_id))
       .catch(() => {});
   };
+
+  if (!canOperate) {
+    return <p>You do not have permission to start ingestion.</p>;
+  }
 
   return (
     <div>

--- a/frontend/src/admin/JobDetail.tsx
+++ b/frontend/src/admin/JobDetail.tsx
@@ -2,10 +2,13 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useApiFetch } from '../apiKey';
 import LogViewer from './LogViewer';
+import useAuth from '../hooks/useAuth';
 
 export default function JobDetail() {
   const { id } = useParams<{ id: string }>();
   const apiFetch = useApiFetch();
+  const { roles } = useAuth();
+  const canOperate = roles.includes('operator') || roles.includes('admin');
   const [status, setStatus] = useState('');
 
   const cancelJob = () => {
@@ -24,7 +27,7 @@ export default function JobDetail() {
         <button
           aria-label="Cancel job"
           onClick={cancelJob}
-          disabled={!!status && status !== 'queued' && status !== 'running'}
+          disabled={!canOperate || (!!status && status !== 'queued' && status !== 'running')}
         >
           Cancel
         </button>
@@ -33,6 +36,7 @@ export default function JobDetail() {
           onClick={() =>
             apiFetch(`/api/admin/ingest/jobs/${id}/rerun`, { method: 'POST' }).then(() => {})
           }
+          disabled={!canOperate}
         >
           Re-run
         </button>

--- a/frontend/src/admin/Sources.tsx
+++ b/frontend/src/admin/Sources.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useApiFetch } from '../apiKey';
+import useAuth from '../hooks/useAuth';
 
 interface Source {
   id: string;
@@ -14,6 +15,8 @@ interface Source {
 
 export default function Sources() {
   const apiFetch = useApiFetch();
+  const { roles } = useAuth();
+  const canOperate = roles.includes('operator') || roles.includes('admin');
   const [sources, setSources] = useState<Source[]>([]);
   const [type, setType] = useState('local_dir');
   const [path, setPath] = useState('');
@@ -134,46 +137,48 @@ export default function Sources() {
   return (
     <div>
       <h2>Sources</h2>
-      <form onSubmit={create} aria-label="Create source form">
-        <label htmlFor="type">Type</label>
-        <select id="type" value={type} onChange={(e) => setType(e.target.value)}>
-          <option value="local_dir">Local</option>
-          <option value="url">URL</option>
-          <option value="url_list">URL List</option>
-        </select>
-        <label htmlFor="label">Label</label>
-        <input id="label" value={label} onChange={(e) => setLabel(e.target.value)} />
-        <label htmlFor="location">Location</label>
-        <input id="location" value={location} onChange={(e) => setLocation(e.target.value)} />
-        <label htmlFor="active">Active</label>
-        <input
-          id="active"
-          type="checkbox"
-          checked={active}
-          onChange={(e) => setActive(e.target.checked)}
-        />
-        <label htmlFor="params">Params</label>
-        <input id="params" value={params} onChange={(e) => setParams(e.target.value)} />
-        {type === 'local_dir' && (
-          <>
-            <label htmlFor="path">Path</label>
-            <input id="path" value={path} onChange={(e) => setPath(e.target.value)} />
-          </>
-        )}
-        {type === 'url' && (
-          <>
-            <label htmlFor="url">URL</label>
-            <input id="url" value={url} onChange={(e) => setUrl(e.target.value)} />
-          </>
-        )}
-        {type === 'url_list' && (
-          <>
-            <label htmlFor="urls">URLs</label>
-            <textarea id="urls" value={urls} onChange={(e) => setUrls(e.target.value)} />
-          </>
-        )}
-        <button type="submit">Add</button>
-      </form>
+      {canOperate && (
+        <form onSubmit={create} aria-label="Create source form">
+          <label htmlFor="type">Type</label>
+          <select id="type" value={type} onChange={(e) => setType(e.target.value)}>
+            <option value="local_dir">Local</option>
+            <option value="url">URL</option>
+            <option value="url_list">URL List</option>
+          </select>
+          <label htmlFor="label">Label</label>
+          <input id="label" value={label} onChange={(e) => setLabel(e.target.value)} />
+          <label htmlFor="location">Location</label>
+          <input id="location" value={location} onChange={(e) => setLocation(e.target.value)} />
+          <label htmlFor="active">Active</label>
+          <input
+            id="active"
+            type="checkbox"
+            checked={active}
+            onChange={(e) => setActive(e.target.checked)}
+          />
+          <label htmlFor="params">Params</label>
+          <input id="params" value={params} onChange={(e) => setParams(e.target.value)} />
+          {type === 'local_dir' && (
+            <>
+              <label htmlFor="path">Path</label>
+              <input id="path" value={path} onChange={(e) => setPath(e.target.value)} />
+            </>
+          )}
+          {type === 'url' && (
+            <>
+              <label htmlFor="url">URL</label>
+              <input id="url" value={url} onChange={(e) => setUrl(e.target.value)} />
+            </>
+          )}
+          {type === 'url_list' && (
+            <>
+              <label htmlFor="urls">URLs</label>
+              <textarea id="urls" value={urls} onChange={(e) => setUrls(e.target.value)} />
+            </>
+          )}
+          <button type="submit">Add</button>
+        </form>
+      )}
 
       <div>
         <label htmlFor="filterActive">Filter Active</label>
@@ -227,6 +232,7 @@ export default function Sources() {
                       prev.map((p) => (p.id === s.id ? { ...p, label: e.target.value } : p))
                     )
                   }
+                  disabled={!canOperate}
                 />
               </td>
               <td>
@@ -238,6 +244,7 @@ export default function Sources() {
                       prev.map((p) => (p.id === s.id ? { ...p, location: e.target.value } : p))
                     )
                   }
+                  disabled={!canOperate}
                 />
               </td>
               <td>
@@ -250,6 +257,7 @@ export default function Sources() {
                         prev.map((p) => (p.id === s.id ? { ...p, path: e.target.value } : p))
                       )
                     }
+                    disabled={!canOperate}
                   />
                 )}
               </td>
@@ -263,6 +271,7 @@ export default function Sources() {
                         prev.map((p) => (p.id === s.id ? { ...p, url: e.target.value } : p))
                       )
                     }
+                    disabled={!canOperate}
                   />
                 )}
               </td>
@@ -276,6 +285,7 @@ export default function Sources() {
                       prev.map((p) => (p.id === s.id ? { ...p, active: e.target.checked } : p))
                     )
                   }
+                  disabled={!canOperate}
                 />
               </td>
               <td>
@@ -293,12 +303,31 @@ export default function Sources() {
                       prev.map((p) => (p.id === s.id ? { ...p, params: e.target.value } : p))
                     )
                   }
+                  disabled={!canOperate}
                 />
               </td>
               <td>
-                <button aria-label={`Save source ${s.id}`} onClick={() => save(s)}>Save</button>
-                <button aria-label={`Delete source ${s.id}`} onClick={() => del(s.id)}>Delete</button>
-                <button aria-label={`Reindex source ${s.id}`} onClick={() => reindex(s.id)}>Reindex</button>
+                <button
+                  aria-label={`Save source ${s.id}`}
+                  onClick={() => save(s)}
+                  disabled={!canOperate}
+                >
+                  Save
+                </button>
+                <button
+                  aria-label={`Delete source ${s.id}`}
+                  onClick={() => del(s.id)}
+                  disabled={!canOperate}
+                >
+                  Delete
+                </button>
+                <button
+                  aria-label={`Reindex source ${s.id}`}
+                  onClick={() => reindex(s.id)}
+                  disabled={!canOperate}
+                >
+                  Reindex
+                </button>
               </td>
             </tr>
           ))}

--- a/frontend/src/apiKey.tsx
+++ b/frontend/src/apiKey.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useMemo, useState } from 'react';
+import { toast } from 'react-toastify';
 
 interface ApiKeyContextValue {
   apiKey: string;
@@ -26,12 +27,18 @@ export function useApiFetch() {
   const { apiKey } = useApiKey();
   return useMemo(
     () =>
-      (input: RequestInfo | URL, init: RequestInit = {}) => {
+      async (input: RequestInfo | URL, init: RequestInit = {}) => {
         const headers = new Headers(init.headers);
         if (apiKey) {
           headers.set('X-API-Key', apiKey);
         }
-        return fetch(input, { ...init, headers });
+        const res = await fetch(input, { ...init, headers });
+        if (res.status === 401) {
+          toast.error('Unauthorized: invalid or missing API key');
+        } else if (res.status === 403) {
+          toast.error('Forbidden: insufficient permissions');
+        }
+        return res;
       },
     [apiKey],
   );

--- a/tests/test_auth_roles.py
+++ b/tests/test_auth_roles.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_roles_endpoint_valid_key():
+    res = client.get("/api/auth/roles", headers={"X-API-Key": "view"})
+    assert res.status_code == 200
+    assert res.json() == {"roles": ["viewer"]}
+
+
+def test_roles_endpoint_missing_key():
+    res = client.get("/api/auth/roles")
+    assert res.status_code == 401
+
+
+def test_roles_endpoint_invalid_key():
+    res = client.get("/api/auth/roles", headers={"X-API-Key": "bad"})
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- expose `/api/auth/roles` endpoint for role lookup from API key
- fetch roles in frontend and gate admin actions accordingly
- show friendly messages for unauthorized or forbidden responses

## Testing
- `pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a65db56c588323b5bc1ac7eefe5efa