### PR TITLE
Refactor schema init to be non-destructive

### DIFF
--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -18,7 +18,7 @@ def _require_conn():
 
 def test_migration_persistence_and_soft_delete(tmp_path):
     conn = _require_conn()
-    service.ensure_schema(conn, Path("schema.sql"), Path("migrations"))
+    service.reset_schema(conn, Path("schema.sql"), Path("migrations"))
     with conn.cursor() as cur:
         cur.execute("ALTER TABLE sources ADD COLUMN IF NOT EXISTS path TEXT")
         cur.execute("ALTER TABLE sources ADD COLUMN IF NOT EXISTS url TEXT")

--- a/tests/test_storage_integration.py
+++ b/tests/test_storage_integration.py
@@ -20,7 +20,7 @@ def _get_conn():
 
 def test_storage_sources_and_jobs(tmp_path):
     conn = _get_conn()
-    service.ensure_schema(conn, Path("schema.sql"), Path("migrations"))
+    service.reset_schema(conn, Path("schema.sql"), Path("migrations"))
     with conn.cursor() as cur:
         cur.execute("ALTER TABLE sources ADD COLUMN IF NOT EXISTS path TEXT")
         cur.execute("ALTER TABLE sources ADD COLUMN IF NOT EXISTS url TEXT")


### PR DESCRIPTION
## Summary
- make `ensure_schema` idempotent and add `reset_schema` helper for tests
- switch ingestion routines to call `ensure_schema` without dropping tables
- adjust tests to use `reset_schema`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71cf5f3988323bca7cc4752e597e2