### PR TITLE
feat: persist API key

### DIFF
--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,16 +1,25 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApiKey } from './apiKey';
 
 export default function Login() {
-  const { setApiKey } = useApiKey();
-  const [key, setKey] = useState('');
+  const { apiKey, setApiKey, clearApiKey } = useApiKey();
+  const [key, setKey] = useState(apiKey);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    setKey(apiKey);
+  }, [apiKey]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setApiKey(key.trim());
     navigate('/');
+  };
+
+  const handleLogout = () => {
+    clearApiKey();
+    setKey('');
   };
 
   return (
@@ -27,6 +36,11 @@ export default function Login() {
         />
         <button type="submit">Save</button>
       </form>
+      {apiKey && (
+        <button type="button" onClick={handleLogout}>
+          Logout
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/apiKey.tsx
+++ b/frontend/src/apiKey.tsx
@@ -1,17 +1,37 @@
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  useCallback,
+} from 'react';
 import { toast } from 'react-toastify';
 
 interface ApiKeyContextValue {
   apiKey: string;
   setApiKey: (k: string) => void;
+  clearApiKey: () => void;
 }
 
 const ApiKeyContext = createContext<ApiKeyContextValue | undefined>(undefined);
 
 export function ApiKeyProvider({ children }: { children: React.ReactNode }) {
-  const [apiKey, setApiKey] = useState('');
+  const [apiKey, setApiKeyState] = useState(
+    () => localStorage.getItem('apiKey') || ''
+  );
+
+  const setApiKey = useCallback((k: string) => {
+    localStorage.setItem('apiKey', k);
+    setApiKeyState(k);
+  }, []);
+
+  const clearApiKey = useCallback(() => {
+    localStorage.removeItem('apiKey');
+    setApiKeyState('');
+  }, []);
+
   return (
-    <ApiKeyContext.Provider value={{ apiKey, setApiKey }}>
+    <ApiKeyContext.Provider value={{ apiKey, setApiKey, clearApiKey }}>
       {children}
     </ApiKeyContext.Provider>
   );


### PR DESCRIPTION
## Summary
- persist API key in localStorage with helper to clear
- preload login form with stored key and offer logout

## Testing
- `CI=true npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a7202621c48323a63188a3c478d7af