### PR TITLE
feat: support multiple file attachments

### DIFF
--- a/frontend/src/chat.test.tsx
+++ b/frontend/src/chat.test.tsx
@@ -88,7 +88,7 @@ test('upload errors surface', async () => {
   const bigFile = new File([new Uint8Array(1024 * 1024 + 1)], 'big.txt');
   const { result } = renderChat();
   await act(async () => {
-    await result.current.send('Hi', bigFile);
+    await result.current.send('Hi', [bigFile]);
   });
   await waitFor(() => {
     expect(result.current.error).toBe('Upload failed');
@@ -144,7 +144,7 @@ test('oversized file triggers local validation without network calls', async () 
     { type: 'application/pdf' }
   );
   await act(async () => {
-    await result.current.send('Hi', hugeFile);
+    await result.current.send('Hi', [hugeFile]);
   });
   expect(fetchSpy).not.toHaveBeenCalled();
   expect(result.current.error).toBe('Arquivo muito grande');

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -1,22 +1,22 @@
 import React, { useRef, useState } from 'react';
 
 interface Props {
-  onSend: (text: string, file?: File | null) => void;
+  onSend: (text: string, files: File[]) => void;
   onCancel: () => void;
   isStreaming: boolean;
 }
 
 export default function Composer({ onSend, onCancel, isStreaming }: Props) {
   const [input, setInput] = useState('');
-  const [file, setFile] = useState<File | null>(null);
+  const [files, setFiles] = useState<File[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const submit = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
     if (!input.trim()) return;
-    onSend(input, file);
+    onSend(input, files);
     setInput('');
-    setFile(null);
+    setFiles([]);
     textareaRef.current?.focus();
   };
 
@@ -44,14 +44,28 @@ export default function Composer({ onSend, onCancel, isStreaming }: Props) {
         id="composer-file"
         type="file"
         accept="application/pdf"
-        onChange={(e) => setFile(e.target.files?.[0] || null)}
+        multiple
+        onChange={(e) => {
+          const newFiles = Array.from(e.target.files || []);
+          setFiles((prev) => [...prev, ...newFiles]);
+          e.target.value = '';
+        }}
       />
-      {file && (
+      {files.length > 0 && (
         <div className="attachment-info">
-          <span>{file.name}</span>
-          <button type="button" onClick={() => setFile(null)}>
-            Remover
-          </button>
+          {files.map((f, idx) => (
+            <div key={idx} className="attachment-item">
+              <span>{f.name}</span>
+              <button
+                type="button"
+                onClick={() =>
+                  setFiles((prev) => prev.filter((_, i) => i !== idx))
+                }
+              >
+                Remover
+              </button>
+            </div>
+          ))}
         </div>
       )}
       {!isStreaming ? (


### PR DESCRIPTION
## Summary
- allow attaching multiple PDF files in Composer
- send all files and include per-file metadata in chat requests

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a734b4bda08323baa7878b472bb773