### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.12-slim
 WORKDIR /app
+EXPOSE 8000
 
 # Install system dependencies for OCR
 RUN apt-get update && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ app:
     - ./logs:/var/log/app
 ```
 
+## Métricas
+
+A aplicação expõe métricas no formato **Prometheus** em `/api/metrics`.
+Ao rodar localmente ou via Docker, você pode verificar as métricas com:
+
+```bash
+curl http://localhost:8000/api/metrics
+```
+
+Esses dados podem ser coletados por Prometheus ou outras ferramentas de monitoramento.
+
 ## Build do chat e frontend
 
 ```bash

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from pypdf import PdfReader
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from .rag import build_context
 from .app_logging import init_logging
@@ -74,6 +75,12 @@ if admin_ui_origins:
 app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR), name="uploads")
 app.include_router(admin_ingest_api.router)
 app.include_router(auth_api.router)
+ 
+# Expose Prometheus metrics
+Instrumentator().instrument(app).expose(
+    app, include_in_schema=False, endpoint="/api/metrics"
+)
+
 app.mount(
     "/",
     StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static"), html=True),

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pdf2image
 Pillow
 requests>=2.31.0
 beautifulsoup4>=4.12.0
+prometheus-fastapi-instrumentator>=6.0.0


### PR DESCRIPTION
## Summary
- expose `/api/metrics` with `prometheus_fastapi_instrumentator`
- document metrics endpoint and expose port in Dockerfile
- install Prometheus instrumentation dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74556fd288323b7d0d0e57b79bfd0