### PR TITLE
feat: build frontend assets during image creation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+frontend/node_modules
+frontend/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM node:20 AS frontend-build
+WORKDIR /workspace/frontend
+COPY frontend/package*.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
 FROM python:3.12-slim
 WORKDIR /app
 EXPOSE 8000
@@ -18,4 +25,5 @@ RUN mkdir -p /var/log/app && \
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
+COPY --from=frontend-build /workspace/app/static ./app/static
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add a Node build stage to compile the frontend
- copy built assets into `app/static` for the runtime image
- ignore frontend node modules during Docker build context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_fastapi_instrumentator')*

------
https://chatgpt.com/codex/tasks/task_e_68a750db60b48323abcadea4384e26a8