### PR TITLE
test: add admin ingestion tests with msw

### DIFF
--- a/frontend/src/admin/__tests__/IngestLocal.test.tsx
+++ b/frontend/src/admin/__tests__/IngestLocal.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ApiKeyProvider } from '../../apiKey';
+import IngestLocal from '../IngestLocal';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import 'whatwg-fetch';
+import { beforeAll, afterEach, afterAll, test, expect } from 'vitest';
+
+const server = setupServer(
+  http.get('/api/auth/roles', () =>
+    HttpResponse.json({ roles: ['operator'] })
+  )
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  localStorage.clear();
+});
+afterAll(() => server.close());
+
+test('starts local ingestion job and shows job id', async () => {
+  server.use(
+    http.post('/api/admin/ingest/local', async () =>
+      HttpResponse.json({ job_id: '42' })
+    )
+  );
+
+  localStorage.setItem('apiKey', 'test');
+  render(
+    <ApiKeyProvider>
+      <IngestLocal />
+    </ApiKeyProvider>
+  );
+
+  const pathInput = await screen.findByLabelText('Path');
+  fireEvent.change(pathInput, { target: { value: '/data' } });
+
+  fireEvent.submit(screen.getByRole('form', { name: 'Local ingestion form' }));
+
+  await waitFor(() => {
+    expect(screen.getByText('Started job 42')).not.toBeNull();
+  });
+});

--- a/frontend/src/admin/__tests__/Sources.test.tsx
+++ b/frontend/src/admin/__tests__/Sources.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ApiKeyProvider } from '../../apiKey';
+import Sources from '../Sources';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import 'whatwg-fetch';
+import { beforeAll, afterEach, afterAll, test, expect } from 'vitest';
+
+const sources: any[] = [
+  { id: '1', type: 'local_dir', label: 'Existing', path: '/data', active: true },
+];
+
+const server = setupServer(
+  http.get('/api/auth/roles', () =>
+    HttpResponse.json({ roles: ['operator'] })
+  ),
+  http.get('/api/admin/ingest/sources', () =>
+    HttpResponse.json({ items: sources })
+  ),
+  http.post('/api/admin/ingest/sources', async ({ request }) => {
+    const body = await request.json();
+    const id = String(sources.length + 1);
+    sources.push({ id, type: body.type, label: body.label, path: body.path, active: body.active });
+    return HttpResponse.json({ id });
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  localStorage.clear();
+});
+afterAll(() => server.close());
+
+test('loads and adds sources', async () => {
+  localStorage.setItem('apiKey', 'test');
+  render(
+    <ApiKeyProvider>
+      <Sources />
+    </ApiKeyProvider>
+  );
+
+  await screen.findByDisplayValue('/data');
+
+  fireEvent.change(screen.getByLabelText('Path'), { target: { value: '/new' } });
+  fireEvent.click(screen.getByText('Add'));
+
+  await screen.findByDisplayValue('/new');
+  expect(sources).toHaveLength(2);
+});


### PR DESCRIPTION
## Summary
- add unit test for IngestLocal verifying job submission via mocked API
- add unit test for Sources verifying list load and source addition

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a760bfda2883239083267098c724a5