### PR TITLE
docs: consolidate admin UI into main frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,10 +410,10 @@ curl -H "X-API-Key: $VIEWER_API_KEY" \
 
 ### Admin UI
 
-A minimal HTML interface lives in `admin-ui/`:
+Admin pages live inside the main frontend project under `frontend/src/admin`. Run the frontend dev server and open the `/admin` route:
 
 ```bash
-cd admin-ui
+cd frontend
 npm install
 npm run dev
 ```


### PR DESCRIPTION
## Summary
- clarify admin pages live under `frontend/src/admin`
- remove outdated reference to separate `admin-ui` folder

## Testing
- `pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a765fdc6208323bce0f96f64db46aa