### PR TITLE
chore: ignore frontend tests in production build

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,5 +16,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.tsx", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- exclude test files from frontend tsconfig so they aren't type-checked during builds

## Testing
- `npm test -- --run`
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78a5e614c8323a6e35f30f87f1eea