### PR TITLE
chore: ensure app depends on db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       watch:
         - path: Dockerfile
           action: rebuild
+    depends_on:
+      - db
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
## Summary
- ensure app service waits for db with depends_on

## Testing
- `pytest`
- `docker compose up --build` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a7917af9a48323b02c16f555ffc01e