### PR TITLE
Use env file for app service

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://pdfkb:pdfkb@db:5432/pdfkb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
           action: rebuild
     depends_on:
       - db
+    env_file:
+      - .env
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
## Summary
- load environment variables for the app service from a `.env` file
- add `.env` with DATABASE_URL pointing at the internal `db` service

## Testing
- `pytest -q`
- `docker-compose run --rm app python ingest.py --docs /app/docs` *(fails: Unsupported config option for services.app: 'develop')*

------
https://chatgpt.com/codex/tasks/task_e_68a7b0c768b88323942bd75b872162b2