### PR TITLE
Fix ingestion CLI premature exit causing fastembed error

### DIFF
--- a/app/ingestion/service.py
+++ b/app/ingestion/service.py
@@ -538,6 +538,13 @@ def cancel_job(job_id: uuid.UUID) -> None:
             )
 
 
+def wait_for_job(job_id: uuid.UUID) -> None:
+    """Block until the given job finishes."""
+    future = _runner.get(job_id)
+    if future:
+        future.result()
+
+
 def get_job(job_id: uuid.UUID) -> Job | None:
     db_url = os.getenv(
         "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/postgres"

--- a/ingest.py
+++ b/ingest.py
@@ -78,7 +78,8 @@ def main(argv: list[str] | None = None) -> None:
         doc_dir = Path(args.docs)
         for doc in _iter_docs(doc_dir):
             log.info("ingesting %s", doc)
-            _service.ingest_local(doc, use_ocr=args.ocr, ocr_lang=args.ocr_lang)
+            job_id = _service.ingest_local(doc, use_ocr=args.ocr, ocr_lang=args.ocr_lang)
+            _service.wait_for_job(job_id)
 
     urls: list[str] = list(args.urls)
     if args.urls_file:
@@ -91,7 +92,8 @@ def main(argv: list[str] | None = None) -> None:
                         urls.append(line)
     if urls:
         log.info("ingesting %d url(s)", len(urls))
-        _service.ingest_urls(urls)
+        job_id = _service.ingest_urls(urls)
+        _service.wait_for_job(job_id)
 
     if args.reindex:
         try:
@@ -99,7 +101,8 @@ def main(argv: list[str] | None = None) -> None:
         except ValueError:
             log.error("--reindex requires a valid UUID")
         else:
-            _service.reindex_source(source_id)
+            job_id = _service.reindex_source(source_id)
+            _service.wait_for_job(job_id)
 
 
 if __name__ != "__main__":  # pragma: no cover - import-time aliasing

--- a/tests/test_ingest_cli_regression.py
+++ b/tests/test_ingest_cli_regression.py
@@ -17,9 +17,22 @@ def test_cli_invokes_service(tmp_path, monkeypatch):
     mod = runpy.run_path("ingest.py", run_name="ingest_cli")
     svc = mod["_service"]
 
-    monkeypatch.setattr(svc, "ingest_local", lambda path, **kw: called.setdefault("local", []).append(path))
-    monkeypatch.setattr(svc, "ingest_urls", lambda urls: called.setdefault("urls", urls))
-    monkeypatch.setattr(svc, "reindex_source", lambda source_id: called.setdefault("reindex", source_id))
+    def fake_ingest_local(path, **kw):
+        called.setdefault("local", []).append(path)
+        return uuid4()
+
+    def fake_ingest_urls(urls):
+        called.setdefault("urls", urls)
+        return uuid4()
+
+    def fake_reindex(source_id):
+        called.setdefault("reindex", source_id)
+        return uuid4()
+
+    monkeypatch.setattr(svc, "ingest_local", fake_ingest_local)
+    monkeypatch.setattr(svc, "ingest_urls", fake_ingest_urls)
+    monkeypatch.setattr(svc, "reindex_source", fake_reindex)
+    monkeypatch.setattr(svc, "wait_for_job", lambda job_id: None)
 
     mod["main"]([
         "--docs", str(docs_dir),


### PR DESCRIPTION
## Summary
- add wait_for_job helper to block on ingestion futures
- update CLI to wait for jobs and adjust regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7b8771d4c8323901066687a56ce04