### PR TITLE
Fix /api/chat POST returning 405 due to early static mount

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -80,13 +80,6 @@ app.include_router(auth_api.router)
 Instrumentator().instrument(app).expose(
     app, include_in_schema=False, endpoint="/api/metrics"
 )
-
-app.mount(
-    "/",
-    StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static"), html=True),
-    name="static",
-)
-
 client = OpenAI() if (OpenAI and os.getenv("OPENAI_API_KEY")) else None
 
 
@@ -311,3 +304,9 @@ async def chat_stream(
             yield {"event": "error", "data": str(e)}
 
     return EventSourceResponse(event_gen())
+
+app.mount(
+    "/",
+    StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static"), html=True),
+    name="static",
+)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -21,10 +21,6 @@ import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from app.main import app, CHAT_MAX_MESSAGE_LENGTH, SESSION_ID_MAX_LENGTH
-from starlette.routing import Mount
-
-# Remove static mount to access API routes during tests
-app.router.routes = [r for r in app.router.routes if not (isinstance(r, Mount) and r.path == '')]
 
 
 def dummy_build_context(q, k):


### PR DESCRIPTION
## Summary
- Mount frontend static files after API routes so requests like `POST /api/chat` reach the proper handlers
- Remove chat test hack that stripped the static mount; tests now use default app configuration

## Testing
- `pytest tests/test_chat.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7baa121488323859b05abc3e2e68f