### PR TITLE
Fix access logging handler replacement

### DIFF
--- a/app/app_logging.py
+++ b/app/app_logging.py
@@ -138,15 +138,15 @@ def init_logging(app: FastAPI | None = None) -> None:
     app_logger.setLevel(log_level)
 
     access_logger = logging.getLogger("uvicorn.access")
-    if not access_logger.handlers:
-        handler = TimedRotatingFileHandler(
-            os.path.join(log_dir, "access.log"),
-            when="midnight",
-            backupCount=retention_days,
-            utc=rotate_utc,
-        )
-        handler.setFormatter(formatter)
-        access_logger.addHandler(handler)
+    access_logger.handlers.clear()
+    handler = TimedRotatingFileHandler(
+        os.path.join(log_dir, "access.log"),
+        when="midnight",
+        backupCount=retention_days,
+        utc=rotate_utc,
+    )
+    handler.setFormatter(formatter)
+    access_logger.addHandler(handler)
     access_logger.setLevel(log_level)
 
     if app is not None:

--- a/tests/test_init_logging.py
+++ b/tests/test_init_logging.py
@@ -31,7 +31,7 @@ def test_init_logging_adds_handlers(monkeypatch, tmp_path):
     access_logger.handlers.clear()
 
 
-def test_init_logging_preserves_existing_access_handlers(monkeypatch, tmp_path):
+def test_init_logging_replaces_existing_access_handlers(monkeypatch, tmp_path):
     monkeypatch.setenv("LOG_DIR", str(tmp_path))
     access_logger = _clear_handlers("uvicorn.access")
 
@@ -40,5 +40,8 @@ def test_init_logging_preserves_existing_access_handlers(monkeypatch, tmp_path):
 
     init_logging()
 
-    assert access_logger.handlers == [stream_handler]
+    assert stream_handler not in access_logger.handlers
+    assert any(
+        isinstance(h, TimedRotatingFileHandler) for h in access_logger.handlers
+    )
     access_logger.handlers.clear()


### PR DESCRIPTION
## Summary
- ensure `uvicorn.access` logger uses our formatter by clearing default handlers
- update logging tests to expect handler replacement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a82f16d7948323a89f6935df2d4591