### PR TITLE
feat: enforce language-aware responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ openai>=1.0
 python-multipart>=0.0.7
 pytest>=8.0
 slowapi>=0.1.8
+langdetect>=1.0.9
 pytesseract
 pdf2image
 Pillow

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -139,3 +139,38 @@ def test_rate_limit(client):
         resp = client.post("/api/chat", data=data, headers=headers)
     assert resp.status_code == 429
 
+
+def test_chat_with_llm_prompt(client):
+    headers = {"X-Forwarded-For": "3.3.3.3"}
+
+    class DummyStream:
+        def __iter__(self):
+            yield types.SimpleNamespace(
+                choices=[types.SimpleNamespace(delta=types.SimpleNamespace(content="hi"))],
+                usage=None,
+            )
+            yield types.SimpleNamespace(
+                choices=[],
+                usage=types.SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+
+    class DummyClient:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self.create))
+            self.messages = None
+
+        def create(self, **kwargs):
+            self.messages = kwargs.get("messages")
+            return DummyStream()
+
+    dummy_client = DummyClient()
+    with patch("app.main.build_context", dummy_build_context), \
+        patch("app.main.client", dummy_client), \
+        patch("app.main.detect", lambda _: "en"):
+        data = {"q": "hi", "k": "1", "sessionId": "sllm"}
+        with client.stream("POST", "/api/chat", data=data, headers=headers) as resp:
+            events = _parse_events(resp)
+    assert any(e[0] == "token" for e in events)
+    assert any(e[0] == "done" for e in events)
+    assert dummy_client.messages[0]["content"] == "Answer the user's question using the supplied context. Reply in en."
+


### PR DESCRIPTION
## Summary
- prompt LLMs to answer using supplied context and detect question language for tailored replies
- support language detection via langdetect and update fallback messages
- test ask and chat endpoints for new language-aware behavior

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a831c6f7308323ac8104a5b52d890d