### PR TITLE
docs: add OpenAI response guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@ ADMIN_UI_ORIGINS=
 # OpenAI
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-3.5-turbo
+OPENAI_LANG=
 
 # ---------------------------------------------------------------------------
 # Branding

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Principais chaves disponíveis:
 
 - **PGHOST**, **PGPORT**, **PGDATABASE**, **PGUSER**, **PGPASSWORD** – conexão com o Postgres/pgvector (padrões: `db`, `5432`, `pdfkb`, `pdfkb`, `pdfkb`).
 - **DOCS_DIR** – pasta padrão para os arquivos. Qualquer `.md` nessa pasta é ingerido junto com os PDFs.
-- **OPENAI_API_KEY**, **OPENAI_MODEL**, **USE_LLM** – integrações com LLM (opcional).
+  - **OPENAI_API_KEY**, **OPENAI_MODEL**, **OPENAI_LANG**, **USE_LLM** – integrações com LLM (opcional).
 - **TOP_K**, **MAX_CONTEXT_CHARS** – ajustes de recuperação de trechos.
 - **UPLOAD_DIR**, **UPLOAD_TTL**, **UPLOAD_MAX_SIZE**, **UPLOAD_ALLOWED_MIME_TYPES** – controle de uploads temporários.
 - **CORS_ALLOW_ORIGINS**, **BRAND_NAME**, **POWERED_BY_LABEL**, **LOGO_URL** – personalização da UI. `POWERED_BY_LABEL` define o texto do rodapé (padrão: "Powered by PDF Knowledge Kit").
@@ -333,6 +333,46 @@ curl http://localhost:8000/api/health
   `SELECT ... ORDER BY embedding <-> :vec LIMIT :k`.
   - Traga os trechos + metadados e alimente o *prompt* do agente (*RAG*).
   - Para respostas fiéis, **mostre as fontes** (caminho do arquivo e página, quando houver).
+
+## Respostas humanizadas com OpenAI
+
+Para gerar uma resposta em linguagem natural a partir dos trechos recuperados, o projeto pode consultar a API da OpenAI.
+Configure as variáveis de ambiente antes de executar:
+
+```bash
+export OPENAI_API_KEY="sua-chave"
+export OPENAI_MODEL="gpt-4o-mini"    # ou outro modelo compatível
+export OPENAI_LANG="pt"              # opcional: força o idioma da resposta
+```
+
+O script `query.py` detecta automaticamente o idioma da pergunta (ou usa `OPENAI_LANG` caso definido) e retorna a resposta no mesmo idioma:
+
+```bash
+python query.py --q "Qual é o objetivo deste projeto?" --k 3
+```
+
+Saída (exemplo):
+
+```
+================================================================================
+Resposta:
+Este projeto cria uma base de conhecimento a partir de PDFs e arquivos Markdown...
+================================================================================
+```
+
+Também é possível obter a resposta pela API:
+
+```bash
+curl -s -X POST http://localhost:8000/api/ask \
+  -H 'Content-Type: application/json' \
+  -d '{"q":"¿Cuál es la capital de Francia?"}'
+```
+
+Resposta:
+
+```json
+{"answer": "La capital de Francia es París.", "from_llm": true}
+```
 
 ## Admin Ingestion
 

--- a/app/main.py
+++ b/app/main.py
@@ -99,12 +99,15 @@ class AskRequest(BaseModel):
 
 def _answer_with_context(question: str, context: str) -> tuple[str, bool]:
     """Generate an answer given a question and context using the LLM if available."""
-    lang_instruction = "Reply in the same language as the question."
-    try:
-        lang = detect(question)
-        lang_instruction = f"Reply in {lang}."
-    except Exception:  # pragma: no cover - detection optional
-        pass
+    lang = os.getenv("OPENAI_LANG")
+    if not lang:
+        try:
+            lang = detect(question)
+        except Exception:  # pragma: no cover - detection optional
+            lang = None
+    lang_instruction = (
+        f"Reply in {lang}." if lang else "Reply in the same language as the question."
+    )
     if client:
         try:  # pragma: no cover - openai optional
             completion = client.chat.completions.create(
@@ -258,12 +261,15 @@ async def chat_stream(
             usage: Dict = {}
             if client:
                 try:
-                    lang_instruction = "Reply in the same language as the question."
-                    try:
-                        lang = detect(q)
-                        lang_instruction = f"Reply in {lang}."
-                    except Exception:  # pragma: no cover - detection optional
-                        pass
+                    lang = os.getenv("OPENAI_LANG")
+                    if not lang:
+                        try:
+                            lang = detect(q)
+                        except Exception:  # pragma: no cover - detection optional
+                            lang = None
+                    lang_instruction = (
+                        f"Reply in {lang}." if lang else "Reply in the same language as the question."
+                    )
                     completion = client.chat.completions.create(
                         model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
                         messages=[

--- a/query.py
+++ b/query.py
@@ -22,11 +22,15 @@ def _answer_with_context(question: str, context: str) -> str:
     if OpenAI and api_key:
         try:  # pragma: no cover - openai optional
             client = OpenAI()
-            try:
-                lang = detect(question)
-                lang_instruction = f"Reply in {lang}."
-            except Exception:  # pragma: no cover - detection optional
-                lang_instruction = "Reply in the same language as the question."
+            lang = os.getenv("OPENAI_LANG")
+            if not lang:
+                try:
+                    lang = detect(question)
+                except Exception:  # pragma: no cover - detection optional
+                    lang = None
+            lang_instruction = (
+                f"Reply in {lang}." if lang else "Reply in the same language as the question."
+            )
             completion = client.chat.completions.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
                 messages=[


### PR DESCRIPTION
## Summary
- documenta configuração de `OPENAI_API_KEY`, `OPENAI_MODEL` e `OPENAI_LANG`
- adiciona seção com exemplos de respostas humanizadas
- permite definir `OPENAI_LANG` para forçar idioma das respostas

## Testing
- `pip install langdetect`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a833d23c748323be4112c956d2e9e7