### PR TITLE
feat(chat): add sidebar and multi-convo routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,8 +15,9 @@ export default function App() {
         <ToastContainer />
         <Routes>
           <Route path="/login" element={<Login />} />
+          <Route path="/" element={<Navigate to="/chat/new" replace />} />
           <Route
-            path="/"
+            path="/chat/:id"
             element={
               <RequireApiKey>
                 <ChatPage />
@@ -33,7 +34,7 @@ export default function App() {
               </RequireApiKey>
             }
           />
-          <Route path="*" element={<Navigate to="/" />} />
+          <Route path="*" element={<Navigate to="/chat/new" replace />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/frontend/src/ChatPage.tsx
+++ b/frontend/src/ChatPage.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import Header from './components/Header';
 import ConversationPane from './components/ConversationPane';
 import Composer from './components/Composer';
 import Footer from './components/Footer';
 import ErrorBanner from './components/ErrorBanner';
-import { useChat } from './chat';
+import Sidebar from './components/Sidebar';
+import { ChatProvider, useChat } from './chat';
 
-function ChatPage() {
+interface ConversationMeta {
+  id: string;
+  title: string;
+  createdAt: string;
+}
+
+function ChatContent() {
   const {
     messages,
     sources,
@@ -31,4 +39,45 @@ function ChatPage() {
   );
 }
 
-export default ChatPage;
+export default function ChatPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [convId, setConvId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored: ConversationMeta[] = JSON.parse(
+      localStorage.getItem('conversations') || '[]'
+    );
+    if (!id || id === 'new') {
+      const newId = crypto.randomUUID();
+      const conv: ConversationMeta = {
+        id: newId,
+        title: 'Novo chat',
+        createdAt: new Date().toISOString(),
+      };
+      localStorage.setItem('conversations', JSON.stringify([...stored, conv]));
+      navigate(`/chat/${newId}`, { replace: true });
+    } else {
+      if (!stored.find((c) => c.id === id)) {
+        const conv: ConversationMeta = {
+          id,
+          title: 'Novo chat',
+          createdAt: new Date().toISOString(),
+        };
+        localStorage.setItem('conversations', JSON.stringify([...stored, conv]));
+      }
+      setConvId(id);
+    }
+  }, [id, navigate]);
+
+  if (!convId) return null;
+
+  return (
+    <ChatProvider conversationId={convId}>
+      <div className="flex flex-1">
+        <Sidebar currentId={convId} />
+        <ChatContent />
+      </div>
+    </ChatProvider>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface ConversationMeta {
+  id: string;
+  title: string;
+  createdAt: string;
+}
+
+function loadConversations(): ConversationMeta[] {
+  const stored = localStorage.getItem('conversations');
+  return stored ? JSON.parse(stored) : [];
+}
+
+export default function Sidebar({ currentId }: { currentId: string }) {
+  const [conversations, setConversations] = useState<ConversationMeta[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setConversations(loadConversations());
+  }, []);
+
+  const persist = (list: ConversationMeta[]) => {
+    setConversations(list);
+    localStorage.setItem('conversations', JSON.stringify(list));
+  };
+
+  const createNew = () => {
+    const id = crypto.randomUUID();
+    const conv: ConversationMeta = {
+      id,
+      title: 'Novo chat',
+      createdAt: new Date().toISOString(),
+    };
+    const list = [...conversations, conv];
+    persist(list);
+    navigate(`/chat/${id}`);
+  };
+
+  const rename = (id: string) => {
+    const title = prompt('Novo título?');
+    if (title) {
+      const list = conversations.map((c) =>
+        c.id === id ? { ...c, title } : c
+      );
+      persist(list);
+    }
+  };
+
+  const remove = (id: string) => {
+    if (!confirm('Excluir conversa?')) return;
+    const list = conversations.filter((c) => c.id !== id);
+    persist(list);
+    localStorage.removeItem(`messages-${id}`);
+    if (id === currentId) {
+      if (list.length > 0) {
+        navigate(`/chat/${list[list.length - 1].id}`);
+      } else {
+        createNew();
+      }
+    }
+  };
+
+  return (
+    <div className="w-64 bg-gray-800 p-4 flex flex-col">
+      <button
+        className="mb-4 rounded bg-blue-600 px-3 py-2 text-sm"
+        onClick={createNew}
+      >
+        Novo Chat
+      </button>
+      <div className="flex-1 overflow-y-auto space-y-2">
+        {conversations.map((c) => (
+          <div
+            key={c.id}
+            className={`rounded p-2 text-sm cursor-pointer ${
+              c.id === currentId ? 'bg-gray-700' : 'hover:bg-gray-700'
+            }`}
+          >
+            <div className="flex justify-between items-center">
+              <span onClick={() => navigate(`/chat/${c.id}`)}>{c.title}</span>
+              <div className="space-x-1">
+                <button onClick={() => rename(c.id)}>✏️</button>
+                <button onClick={() => remove(c.id)}>🗑️</button>
+              </div>
+            </div>
+            <div className="text-xs text-gray-400">
+              {new Date(c.createdAt).toLocaleString()}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { ChatProvider } from './chat';
 import { ConfigProvider } from './config';
 import { ApiKeyProvider } from './apiKey';
 import './theme.css';
@@ -10,9 +9,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <ApiKeyProvider>
       <ConfigProvider>
-        <ChatProvider>
-          <App />
-        </ChatProvider>
+        <App />
       </ConfigProvider>
     </ApiKeyProvider>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- add conversation sidebar with new, rename and delete actions
- support conversation IDs with dedicated routes and local storage
- refactor chat provider and layout for sidebar + conversation pane

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa14e1aba88323b234cb625a03df90