### PR TITLE
feat(frontend): improve chat messages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "dompurify": "^2.4.3",
         "markdown-it": "^13.0.1",
+        "prismjs": "^1.30.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.30.1",
@@ -3784,6 +3785,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/psl": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "dompurify": "^2.4.3",
     "markdown-it": "^13.0.1",
+    "prismjs": "^1.30.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1",

--- a/frontend/src/components/Message.tsx
+++ b/frontend/src/components/Message.tsx
@@ -1,10 +1,26 @@
 import React from 'react';
 import MarkdownIt from 'markdown-it';
 import DOMPurify from 'dompurify';
+import Prism from 'prismjs';
+import 'prismjs/themes/prism.css';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-json';
 import { Message as MessageType, Source } from '../chat';
 import SourcesList from './SourcesList';
 
-const md = new MarkdownIt();
+const md = new MarkdownIt({
+  highlight: function (str, lang) {
+    if (lang && Prism.languages[lang]) {
+      try {
+        return `<pre class="language-${lang}"><code>${Prism.highlight(str, Prism.languages[lang], lang)}</code></pre>`;
+      } catch (__) {}
+    }
+    return `<pre class="language-${lang}"><code>${md.utils.escapeHtml(str)}</code></pre>`;
+  },
+});
 
 interface Props {
   message: MessageType;
@@ -12,6 +28,8 @@ interface Props {
 }
 
 export default function Message({ message, sources }: Props) {
+  const avatar = message.role === 'assistant' ? '🤖' : '🧑';
+
   return (
     <div
       className={`msg ${message.role}`}
@@ -22,17 +40,20 @@ export default function Message({ message, sources }: Props) {
           : undefined
       }
     >
-      <div
-        dangerouslySetInnerHTML={{
-          __html: DOMPurify.sanitize(md.render(message.content)),
-        }}
-      />
-      {message.status === 'streaming' && (
-        <div className="typing-indicator">Digitando...</div>
-      )}
-      {message.role === 'assistant' && sources && (
-        <SourcesList sources={sources} />
-      )}
+      <div className="avatar">{avatar}</div>
+      <div className="bubble">
+        <div
+          dangerouslySetInnerHTML={{
+            __html: DOMPurify.sanitize(md.render(message.content)),
+          }}
+        />
+        {message.status === 'streaming' && (
+          <div className="typing-indicator">Digitando...</div>
+        )}
+        {message.role === 'assistant' && sources && (
+          <SourcesList sources={sources} />
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -82,3 +82,46 @@ button {
 a {
   color: var(--color-accent);
 }
+
+/* Message bubbles */
+.msg {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.msg.user {
+  flex-direction: row-reverse;
+}
+
+.msg .avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  background-color: var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+.msg.user .avatar {
+  margin-left: 0.5rem;
+  margin-right: 0;
+}
+
+.msg .bubble {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  max-width: 80%;
+}
+
+.msg.assistant .bubble {
+  background-color: var(--color-surface);
+}
+
+.msg.user .bubble {
+  background-color: var(--color-accent);
+  color: var(--color-surface);
+}


### PR DESCRIPTION
## Summary
- add Prism-based syntax highlighting
- display chat messages with avatars and rounded bubbles
- style user and assistant messages with distinct backgrounds

## Testing
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa2f14a4988323a36cd934baaa00bc