### PR TITLE
Add header actions and confidentiality footer with theme toggle

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -2,5 +2,20 @@ import { useConfig } from '../config';
 
 export default function Footer() {
   const { POWERED_BY_LABEL } = useConfig();
-  return <footer>{POWERED_BY_LABEL}</footer>;
+  return (
+    <footer>
+      <p>
+        Este conteúdo é confidencial. Consulte os{' '}
+        <a href="/terms" target="_blank" rel="noopener noreferrer">
+          Termos de Uso
+        </a>{' '}
+        e a{' '}
+        <a href="/privacy" target="_blank" rel="noopener noreferrer">
+          Política de Privacidade
+        </a>
+        .
+      </p>
+      <span>{POWERED_BY_LABEL}</span>
+    </footer>
+  );
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,11 +1,50 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useConfig } from '../config';
 
 export default function Header() {
   const { BRAND_NAME, LOGO_URL } = useConfig();
+  const navigate = useNavigate();
+  const [theme, setTheme] = useState(
+    localStorage.getItem('theme') || 'light'
+  );
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
   return (
     <header>
-      {LOGO_URL && <img src={LOGO_URL} alt={BRAND_NAME} className="logo" />}
-      <h1>{BRAND_NAME}</h1>
+      <div className="brand">
+        {LOGO_URL && <img src={LOGO_URL} alt={BRAND_NAME} className="logo" />}
+        <h1>{BRAND_NAME}</h1>
+      </div>
+      <div className="header-actions">
+        <button onClick={() => navigate('/chat/new')}>Novo Chat</button>
+        <button className="icon-button" onClick={toggleTheme}>
+          {theme === 'light' ? '🌙' : '☀️'}
+        </button>
+        <div className="user-menu">
+          <button
+            className="icon-button"
+            onClick={() => setMenuOpen((o) => !o)}
+          >
+            ☺
+          </button>
+          {menuOpen && (
+            <div className="menu">
+              <a href="#">Perfil</a>
+              <a href="#">Sair</a>
+            </div>
+          )}
+        </div>
+      </div>
     </header>
   );
 }

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1,3 +1,4 @@
+/* Light theme (default) */
 :root {
   --color-bg: #f7f7f8;
   --color-surface: #ffffff;
@@ -8,14 +9,13 @@
     'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #343541;
-    --color-surface: #444654;
-    --color-text: #ececf1;
-    --color-accent: #10a37f;
-    --color-border: #565869;
-  }
+/* Dark theme */
+:root[data-theme='dark'] {
+  --color-bg: #343541;
+  --color-surface: #444654;
+  --color-text: #ececf1;
+  --color-accent: #10a37f;
+  --color-border: #565869;
 }
 
 body {
@@ -33,6 +33,13 @@ body {
 .bg-gray-900 { background-color: var(--color-bg); }
 .text-gray-100 { color: var(--color-text); }
 .p-4 { padding: 1rem; }
+.icon-button {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  padding: 0.25rem;
+  cursor: pointer;
+}
 
 header, footer {
   background-color: var(--color-surface);
@@ -42,12 +49,56 @@ header, footer {
 header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
   border-bottom: 1px solid var(--color-border);
 }
 
+header .brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.user-menu {
+  position: relative;
+}
+
+.user-menu .menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.25rem);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  min-width: 8rem;
+  z-index: 10;
+}
+
+.user-menu .menu a {
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  color: var(--color-text);
+}
+
+.user-menu .menu a:hover {
+  background-color: var(--color-bg);
+}
+
 footer {
   border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: center;
 }
 
 .conversation {


### PR DESCRIPTION
## Summary
- add "Novo Chat" chat creation button, theme toggle, and user menu in the header
- show confidentiality notice with links to terms and privacy policy in the footer
- update CSS for manual dark/light theme and new header/footer layouts

## Testing
- `npx vitest run` *(fails: Unexpected end of file in chat.test.tsx)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab416f0c7083239447ca4cc6bb253e