### PR TITLE
feat: responsive sidebar and accessibility enhancements

### DIFF
--- a/frontend/src/ChatPage.tsx
+++ b/frontend/src/ChatPage.tsx
@@ -14,7 +14,7 @@ interface ConversationMeta {
   createdAt: string;
 }
 
-function ChatContent() {
+function ChatContent({ onMenuClick }: { onMenuClick: () => void }) {
   const {
     messages,
     sources,
@@ -28,7 +28,7 @@ function ChatContent() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <Header />
+      <Header onMenuClick={onMenuClick} />
       {error && (
         <ErrorBanner message={error} onClose={clearError} onRetry={retry} />
       )}
@@ -43,6 +43,7 @@ export default function ChatPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [convId, setConvId] = useState<string | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
     const stored: ConversationMeta[] = JSON.parse(
@@ -74,9 +75,20 @@ export default function ChatPage() {
 
   return (
     <ChatProvider conversationId={convId}>
-      <div className="flex flex-1">
-        <Sidebar currentId={convId} />
-        <ChatContent />
+      <div className="flex flex-1 relative">
+        <Sidebar
+          currentId={convId}
+          isOpen={sidebarOpen}
+          onClose={() => setSidebarOpen(false)}
+        />
+        {sidebarOpen && (
+          <div
+            className="fixed inset-0 bg-black/50 md:hidden z-10"
+            onClick={() => setSidebarOpen(false)}
+            aria-hidden="true"
+          />
+        )}
+        <ChatContent onMenuClick={() => setSidebarOpen(true)} />
       </div>
     </ChatProvider>
   );

--- a/frontend/src/components/Composer.tsx
+++ b/frontend/src/components/Composer.tsx
@@ -107,9 +107,14 @@ export default function Composer({ onSend, onCancel, isStreaming }: Props) {
           placeholder="Pergunte algo"
           onKeyDown={handleKeyDown}
           maxLength={5000}
+          aria-label="Mensagem"
         />
         <div className="composer-toolbar">
-          <label htmlFor="composer-file" className="icon-button">
+          <label
+            htmlFor="composer-file"
+            className="icon-button"
+            aria-label="Anexar arquivo"
+          >
             <AttachIcon />
           </label>
           {isStreaming ? (
@@ -120,11 +125,16 @@ export default function Composer({ onSend, onCancel, isStreaming }: Props) {
                 onCancel();
                 textareaRef.current?.focus();
               }}
+              aria-label="Interromper resposta"
             >
               <StopIcon />
             </button>
           ) : (
-            <button type="submit" className="icon-button">
+            <button
+              type="submit"
+              className="icon-button"
+              aria-label="Enviar mensagem"
+            >
               <SendIcon />
             </button>
           )}
@@ -149,6 +159,7 @@ export default function Composer({ onSend, onCancel, isStreaming }: Props) {
                 onClick={() =>
                   setFiles((prev) => prev.filter((_, i) => i !== idx))
                 }
+                aria-label="Remover arquivo"
               >
                 ✕
               </button>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useConfig } from '../config';
 
-export default function Header() {
+interface Props {
+  onMenuClick?: () => void;
+}
+
+export default function Header({ onMenuClick }: Props) {
   const { BRAND_NAME, LOGO_URL } = useConfig();
   const navigate = useNavigate();
   const [theme, setTheme] = useState(
@@ -20,27 +24,56 @@ export default function Header() {
   };
 
   return (
-    <header>
-      <div className="brand">
-        {LOGO_URL && <img src={LOGO_URL} alt={BRAND_NAME} className="logo" />}
-        <h1>{BRAND_NAME}</h1>
+    <header className="flex items-center justify-between p-4">
+      <div className="flex items-center">
+        {onMenuClick && (
+          <button
+            className="mr-2 p-2 md:hidden"
+            onClick={onMenuClick}
+            aria-label="Abrir menu"
+          >
+            ☰
+          </button>
+        )}
+        <div className="brand flex items-center">
+          {LOGO_URL && (
+            <img src={LOGO_URL} alt={BRAND_NAME} className="logo" />
+          )}
+          <h1>{BRAND_NAME}</h1>
+        </div>
       </div>
-      <div className="header-actions">
-        <button onClick={() => navigate('/chat/new')}>Novo Chat</button>
-        <button className="icon-button" onClick={toggleTheme}>
+      <div className="header-actions flex items-center space-x-2">
+        <button
+          onClick={() => navigate('/chat/new')}
+          aria-label="Novo chat"
+        >
+          Novo Chat
+        </button>
+        <button
+          className="icon-button"
+          onClick={toggleTheme}
+          aria-label="Alternar tema"
+        >
           {theme === 'light' ? '🌙' : '☀️'}
         </button>
-        <div className="user-menu">
+        <div className="user-menu relative">
           <button
             className="icon-button"
             onClick={() => setMenuOpen((o) => !o)}
+            aria-label="Menu do usuário"
+            aria-haspopup="true"
+            aria-expanded={menuOpen}
           >
             ☺
           </button>
           {menuOpen && (
-            <div className="menu">
-              <a href="#">Perfil</a>
-              <a href="#">Sair</a>
+            <div className="menu" role="menu">
+              <a href="#" role="menuitem">
+                Perfil
+              </a>
+              <a href="#" role="menuitem">
+                Sair
+              </a>
             </div>
           )}
         </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -12,7 +12,13 @@ function loadConversations(): ConversationMeta[] {
   return stored ? JSON.parse(stored) : [];
 }
 
-export default function Sidebar({ currentId }: { currentId: string }) {
+interface Props {
+  currentId: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ currentId, isOpen, onClose }: Props) {
   const [conversations, setConversations] = useState<ConversationMeta[]>([]);
   const navigate = useNavigate();
 
@@ -61,11 +67,28 @@ export default function Sidebar({ currentId }: { currentId: string }) {
     }
   };
 
+  const navigateTo = (id: string) => {
+    navigate(`/chat/${id}`);
+    onClose();
+  };
+
   return (
-    <div className="w-64 bg-gray-800 p-4 flex flex-col">
+    <nav
+      className={
+        `bg-gray-800 p-4 flex flex-col w-64 z-20 fixed inset-y-0 left-0 transform transition-transform duration-200 ` +
+        `md:static md:translate-x-0 md:flex ${isOpen ? 'translate-x-0' : '-translate-x-full'}`
+      }
+      aria-label="Histórico de conversas"
+    >
+      <div className="flex justify-end md:hidden">
+        <button onClick={onClose} aria-label="Fechar menu">
+          ✕
+        </button>
+      </div>
       <button
         className="mb-4 rounded bg-blue-600 px-3 py-2 text-sm"
         onClick={createNew}
+        aria-label="Iniciar novo chat"
       >
         Novo Chat
       </button>
@@ -76,12 +99,35 @@ export default function Sidebar({ currentId }: { currentId: string }) {
             className={`rounded p-2 text-sm cursor-pointer ${
               c.id === currentId ? 'bg-gray-700' : 'hover:bg-gray-700'
             }`}
+            role="button"
+            tabIndex={0}
+            aria-pressed={c.id === currentId}
+            onClick={() => navigateTo(c.id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') navigateTo(c.id);
+            }}
           >
             <div className="flex justify-between items-center">
-              <span onClick={() => navigate(`/chat/${c.id}`)}>{c.title}</span>
+              <span>{c.title}</span>
               <div className="space-x-1">
-                <button onClick={() => rename(c.id)}>✏️</button>
-                <button onClick={() => remove(c.id)}>🗑️</button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    rename(c.id);
+                  }}
+                  aria-label="Renomear conversa"
+                >
+                  ✏️
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    remove(c.id);
+                  }}
+                  aria-label="Excluir conversa"
+                >
+                  🗑️
+                </button>
               </div>
             </div>
             <div className="text-xs text-gray-400">
@@ -90,6 +136,6 @@ export default function Sidebar({ currentId }: { currentId: string }) {
           </div>
         ))}
       </div>
-    </div>
+    </nav>
   );
 }


### PR DESCRIPTION
## Summary
- Collapse sidebar on small screens with mobile overlay and toggleable menu
- Add ARIA labels and keyboard support to header, sidebar and composer
- Improve mobile friendliness of chat layout

## Testing
- `npm --prefix frontend test` *(fails: Unexpected end of file in chat.test.tsx)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5ecb3fb88323970cb46910c005ad