### PR TITLE
feat: add theme context and theme toggle

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useConfig } from '../config';
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useConfig } from "../config";
+import { useTheme } from "../theme";
 
 interface Props {
   onMenuClick?: () => void;
@@ -9,19 +10,8 @@ interface Props {
 export default function Header({ onMenuClick }: Props) {
   const { BRAND_NAME, LOGO_URL } = useConfig();
   const navigate = useNavigate();
-  const [theme, setTheme] = useState(
-    localStorage.getItem('theme') || 'light'
-  );
   const [menuOpen, setMenuOpen] = useState(false);
-
-  useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
-  }, [theme]);
-
-  const toggleTheme = () => {
-    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
-  };
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <header className="flex items-center justify-between p-4">
@@ -36,17 +26,12 @@ export default function Header({ onMenuClick }: Props) {
           </button>
         )}
         <div className="brand flex items-center">
-          {LOGO_URL && (
-            <img src={LOGO_URL} alt={BRAND_NAME} className="logo" />
-          )}
+          {LOGO_URL && <img src={LOGO_URL} alt={BRAND_NAME} className="logo" />}
           <h1>{BRAND_NAME}</h1>
         </div>
       </div>
       <div className="header-actions flex items-center space-x-2">
-        <button
-          onClick={() => navigate('/chat/new')}
-          aria-label="Novo chat"
-        >
+        <button onClick={() => navigate("/chat/new")} aria-label="Novo chat">
           Novo Chat
         </button>
         <button
@@ -54,7 +39,7 @@ export default function Header({ onMenuClick }: Props) {
           onClick={toggleTheme}
           aria-label="Alternar tema"
         >
-          {theme === 'light' ? '🌙' : '☀️'}
+          {theme === "light" ? "🌙" : "☀️"}
         </button>
         <div className="user-menu relative">
           <button

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,16 +1,19 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import { ConfigProvider } from './config';
-import { ApiKeyProvider } from './apiKey';
-import './theme.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import { ConfigProvider } from "./config";
+import { ApiKeyProvider } from "./apiKey";
+import { ThemeProvider } from "./theme";
+import "./theme.css";
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <ApiKeyProvider>
-      <ConfigProvider>
-        <App />
-      </ConfigProvider>
-    </ApiKeyProvider>
+    <ThemeProvider>
+      <ApiKeyProvider>
+        <ConfigProvider>
+          <App />
+        </ConfigProvider>
+      </ApiKeyProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const themeVariables: Record<Theme, Record<string, string>> = {
+  light: {
+    "--color-bg": "#f7f7f8",
+    "--color-surface": "#ffffff",
+    "--color-text": "#343541",
+    "--color-accent": "#10a37f",
+    "--color-border": "#e5e7eb",
+  },
+  dark: {
+    "--color-bg": "#343541",
+    "--color-surface": "#444654",
+    "--color-text": "#ececf1",
+    "--color-accent": "#10a37f",
+    "--color-border": "#565869",
+  },
+};
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement;
+  const vars = themeVariables[theme];
+  Object.entries(vars).forEach(([key, value]) => {
+    root.style.setProperty(key, value);
+  });
+  document.body.classList.remove("light", "dark");
+  document.body.classList.add(theme);
+  localStorage.setItem("theme", theme);
+  localStorage.setItem("theme-vars", JSON.stringify(vars));
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    return stored || "light";
+  });
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((t) => (t === "light" ? "dark" : "light"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add ThemeProvider/useTheme for persisting theme selection in localStorage
- wrap app with ThemeProvider and expose toggle button in header

## Testing
- `npm test -- --run` (fails: Unexpected end of file in chat.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68ab622e346083239dc0dbc4a66e87d6