### PR TITLE
Add disclaimer component to chat page

### DIFF
--- a/frontend/src/ChatPage.tsx
+++ b/frontend/src/ChatPage.tsx
@@ -4,6 +4,7 @@ import Header from './components/Header';
 import ConversationPane from './components/ConversationPane';
 import Composer from './components/Composer';
 import Footer from './components/Footer';
+import Disclaimer from './components/Disclaimer';
 import ErrorBanner from './components/ErrorBanner';
 import Sidebar from './components/Sidebar';
 import { ChatProvider, useChat } from './chat';
@@ -34,6 +35,7 @@ function ChatContent({ onMenuClick }: { onMenuClick: () => void }) {
       )}
       <ConversationPane messages={messages} sources={sources ?? undefined} />
       <Composer onSend={send} onCancel={cancel} isStreaming={isStreaming} />
+      <Disclaimer />
       <Footer />
     </div>
   );

--- a/frontend/src/components/Disclaimer.tsx
+++ b/frontend/src/components/Disclaimer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Disclaimer() {
+  return (
+    <div className="disclaimer">
+      As respostas podem conter imprecisões; verifique as informações e utilize o conteúdo sob sua própria responsabilidade.
+    </div>
+  );
+}

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -101,6 +101,17 @@ footer {
   text-align: center;
 }
 
+.disclaimer {
+  position: sticky;
+  bottom: 0;
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.75rem;
+  text-align: center;
+  padding: 0.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
 .conversation {
   flex: 1 1 0%;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- add Disclaimer component with warning text
- render Disclaimer above Footer on chat page and style per theme

## Testing
- `npm test` *(fails: Unexpected end of file in src/chat.test.tsx)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab637162008323aaa1fa92d010fe53