### PR TITLE
refactor: remove sources from message component

### DIFF
--- a/frontend/src/components/Message.tsx
+++ b/frontend/src/components/Message.tsx
@@ -8,8 +8,7 @@ import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-json';
-import { Message as MessageType, Source, useChat } from '../chat';
-import SourcesList from './SourcesList';
+import { Message as MessageType, useChat } from '../chat';
 
 const md: MarkdownIt = new MarkdownIt();
 
@@ -26,10 +25,9 @@ md.set({
 
 interface Props {
   message: MessageType;
-  sources?: Source[];
 }
 
-export default function Message({ message, sources }: Props) {
+export default function Message({ message }: Props) {
   const avatar = message.role === 'assistant' ? '🤖' : '🧑';
   const { regenerate } = useChat();
 
@@ -105,9 +103,6 @@ export default function Message({ message, sources }: Props) {
             <span />
             <span />
           </div>
-        )}
-        {message.role === 'assistant' && sources && (
-          <SourcesList sources={sources} />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove SourcesList import and sources prop usage from Message component
- simplify Message component props

## Testing
- `npm test -- --run` (fails: ERROR: Unexpected end of file in src/chat.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68ab70ae58948323a1f2b6d481351b01