### PR TITLE
refactor: drop sources prop from ConversationPane

### DIFF
--- a/frontend/src/ChatPage.tsx
+++ b/frontend/src/ChatPage.tsx
@@ -16,16 +16,8 @@ interface ConversationMeta {
 }
 
 function ChatContent({ onMenuClick }: { onMenuClick: () => void }) {
-  const {
-    messages,
-    sources,
-    send,
-    isStreaming,
-    cancel,
-    error,
-    clearError,
-    retry,
-  } = useChat();
+  const { messages, send, isStreaming, cancel, error, clearError, retry } =
+    useChat();
 
   return (
     <div className="flex flex-1 flex-col">
@@ -33,7 +25,7 @@ function ChatContent({ onMenuClick }: { onMenuClick: () => void }) {
       {error && (
         <ErrorBanner message={error} onClose={clearError} onRetry={retry} />
       )}
-      <ConversationPane messages={messages} sources={sources ?? undefined} />
+      <ConversationPane messages={messages} />
       <Composer onSend={send} onCancel={cancel} isStreaming={isStreaming} />
       <Disclaimer />
       <Footer />

--- a/frontend/src/components/ConversationPane.tsx
+++ b/frontend/src/components/ConversationPane.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ChatMessage from './Message';
-import { Message, Source } from '../chat';
+import { Message } from '../chat';
 
 interface Props {
   messages: Message[];
-  sources?: Source[] | null;
 }
 
-export default function ConversationPane({ messages, sources }: Props) {
+export default function ConversationPane({ messages }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
 
@@ -35,15 +34,7 @@ export default function ConversationPane({ messages, sources }: Props) {
   return (
     <div className="conversation" ref={containerRef} role="list">
       {messages.map((m, i) => (
-        <ChatMessage
-          key={i}
-          message={m}
-          sources={
-            i === messages.length - 1 && m.role === 'assistant'
-              ? sources || undefined
-              : undefined
-          }
-        />
+        <ChatMessage key={i} message={m} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- remove unused sources prop from ConversationPane component
- update ChatPage to render ConversationPane with messages only

## Testing
- `npm test` *(fails: Unexpected end of file)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab94acdaec832384f7ed3165bf97be