### PR TITLE
feat: display sources for assistant messages

### DIFF
--- a/frontend/src/ChatPage.tsx
+++ b/frontend/src/ChatPage.tsx
@@ -16,8 +16,16 @@ interface ConversationMeta {
 }
 
 function ChatContent({ onMenuClick }: { onMenuClick: () => void }) {
-  const { messages, send, isStreaming, cancel, error, clearError, retry } =
-    useChat();
+  const {
+    messages,
+    send,
+    isStreaming,
+    cancel,
+    error,
+    clearError,
+    retry,
+    sources,
+  } = useChat();
 
   return (
     <div className="flex flex-1 flex-col">
@@ -25,7 +33,7 @@ function ChatContent({ onMenuClick }: { onMenuClick: () => void }) {
       {error && (
         <ErrorBanner message={error} onClose={clearError} onRetry={retry} />
       )}
-      <ConversationPane messages={messages} />
+      <ConversationPane messages={messages} sources={sources ?? undefined} />
       <Composer onSend={send} onCancel={cancel} isStreaming={isStreaming} />
       <Disclaimer />
       <Footer />

--- a/frontend/src/chat.test.tsx
+++ b/frontend/src/chat.test.tsx
@@ -214,6 +214,8 @@ test('regenerate resends last request', async () => {
   expect(calls).toBe(2);
   expect(result.current.messages.length).toBe(4);
 
+});
+
 test('too many files trigger local validation', async () => {
   const fetchSpy = vi.spyOn(global, 'fetch');
   const { result } = renderChat();

--- a/frontend/src/components/ConversationPane.tsx
+++ b/frontend/src/components/ConversationPane.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ChatMessage from './Message';
-import { Message } from '../chat';
+import { Message, Source } from '../chat';
 
 interface Props {
   messages: Message[];
+  sources?: Source[];
 }
 
-export default function ConversationPane({ messages }: Props) {
+export default function ConversationPane({ messages, sources }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
 
@@ -34,7 +35,15 @@ export default function ConversationPane({ messages }: Props) {
   return (
     <div className="conversation" ref={containerRef} role="list">
       {messages.map((m, i) => (
-        <ChatMessage key={i} message={m} />
+        <ChatMessage
+          key={i}
+          message={m}
+          sources={
+            i === messages.length - 1 && m.role === 'assistant'
+              ? sources
+              : undefined
+          }
+        />
       ))}
     </div>
   );

--- a/frontend/src/components/Message.tsx
+++ b/frontend/src/components/Message.tsx
@@ -8,7 +8,8 @@ import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-json';
-import { Message as MessageType, useChat } from '../chat';
+import { Message as MessageType, Source, useChat } from '../chat';
+import SourcesList from './SourcesList';
 
 const md: MarkdownIt = new MarkdownIt();
 
@@ -25,9 +26,10 @@ md.set({
 
 interface Props {
   message: MessageType;
+  sources?: Source[];
 }
 
-export default function Message({ message }: Props) {
+export default function Message({ message, sources }: Props) {
   const avatar = message.role === 'assistant' ? '🤖' : '🧑';
   const { regenerate } = useChat();
 
@@ -66,44 +68,47 @@ export default function Message({ message }: Props) {
       }
     >
       <div className="avatar">{avatar}</div>
-      <div className="bubble">
-        <div className="toolbar">
-          <button onClick={handleCopy} aria-label="Copiar">📋</button>
-          {message.role === 'assistant' && (
-            <>
-              <button
-                onClick={handleRegenerate}
-                aria-label="Regenerar"
-              >
-                🔄
-              </button>
-              <button
-                onClick={() => handleFeedback(true)}
-                aria-label="Feedback positivo"
-              >
-                👍
-              </button>
-              <button
-                onClick={() => handleFeedback(false)}
-                aria-label="Feedback negativo"
-              >
-                👎
-              </button>
-            </>
+      <div>
+        <div className="bubble">
+          <div className="toolbar">
+            <button onClick={handleCopy} aria-label="Copiar">📋</button>
+            {message.role === 'assistant' && (
+              <>
+                <button
+                  onClick={handleRegenerate}
+                  aria-label="Regenerar"
+                >
+                  🔄
+                </button>
+                <button
+                  onClick={() => handleFeedback(true)}
+                  aria-label="Feedback positivo"
+                >
+                  👍
+                </button>
+                <button
+                  onClick={() => handleFeedback(false)}
+                  aria-label="Feedback negativo"
+                >
+                  👎
+                </button>
+              </>
+            )}
+          </div>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(md.render(message.content)),
+            }}
+          />
+          {message.status === 'streaming' && (
+            <div className="typing-indicator" aria-label="Digitando...">
+              <span />
+              <span />
+              <span />
+            </div>
           )}
         </div>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(md.render(message.content)),
-          }}
-        />
-        {message.status === 'streaming' && (
-          <div className="typing-indicator" aria-label="Digitando...">
-            <span />
-            <span />
-            <span />
-          </div>
-        )}
+        {sources && <SourcesList sources={sources} />}
       </div>
     </div>
   );

--- a/frontend/src/components/SourcesList.tsx
+++ b/frontend/src/components/SourcesList.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Source } from '../chat';
+
+interface Props {
+  sources: Source[];
+}
+
+export default function SourcesList({ sources }: Props) {
+  if (!sources || sources.length === 0) return null;
+
+  return (
+    <div className="sources-list">
+      <h4>Fontes</h4>
+      <ul>
+        {sources.map((s, i) => (
+          <li key={i}>
+            {s.path} (chunk {s.chunk_index})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show source references beneath assistant messages
- plumb `sources` through chat components from hook to UI
- add SourcesList component and fix chat tests

## Testing
- `npm run build`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aba2d254c883239d72c9d3131898a0