### PR TITLE
feat: improve sidebar toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pdf-knowledge-kit-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "dompurify": "^2.4.3",
         "markdown-it": "^13.0.1",
         "prismjs": "^1.30.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1",
-    "react-toastify": "^11.0.5"
+    "react-toastify": "^11.0.5",
+    "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import clsx from 'clsx';
 
 interface ConversationMeta {
   id: string;
@@ -74,10 +75,12 @@ export default function Sidebar({ currentId, isOpen, onClose }: Props) {
 
   return (
     <nav
-      className={
-        `bg-gray-800 p-4 flex flex-col w-64 z-20 fixed inset-y-0 left-0 transform transition-transform duration-200 ` +
-        `md:static md:translate-x-0 md:flex ${isOpen ? 'translate-x-0' : '-translate-x-full'}`
-      }
+      className={clsx(
+        'fixed inset-y-0 left-0 w-64 transform transition-transform duration-200 bg-gray-800 p-4 flex flex-col z-20 md:static md:translate-x-0 md:flex',
+        isOpen
+          ? 'translate-x-0 pointer-events-auto'
+          : '-translate-x-full pointer-events-none'
+      )}
       aria-label="Histórico de conversas"
     >
       <div className="flex justify-end md:hidden">


### PR DESCRIPTION
## Summary
- streamline Sidebar component with clsx and Tailwind utilities
- add pointer-event toggling when sidebar closed
- expose clsx dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abafc981008323b03f1c3ca0475bc9