### PR TITLE
fix header menu layering and outside click handling

### DIFF
--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Header from './Header';
+import { MemoryRouter } from 'react-router-dom';
+import { ApiKeyProvider } from '../apiKey';
+import { ConfigProvider } from '../config';
+import { ThemeProvider } from '../theme';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import 'whatwg-fetch';
+import { beforeAll, afterEach, afterAll, test, expect } from 'vitest';
+
+const server = setupServer(
+  http.get('/api/config', () => HttpResponse.json({}))
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  localStorage.clear();
+});
+afterAll(() => server.close());
+
+function renderHeader() {
+  return render(
+    <MemoryRouter>
+      <ApiKeyProvider>
+        <ConfigProvider>
+          <ThemeProvider>
+            <Header />
+          </ThemeProvider>
+        </ConfigProvider>
+      </ApiKeyProvider>
+      <button data-testid="outside">outside</button>
+    </MemoryRouter>
+  );
+}
+
+test('closes user menu when clicking outside', async () => {
+  renderHeader();
+  const toggle = screen.getByRole('button', { name: 'Menu do usuário' });
+  fireEvent.click(toggle);
+  await screen.findByRole('menu');
+  fireEvent.mouseDown(screen.getByTestId('outside'));
+  await waitFor(() => {
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+});

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useConfig } from "../config";
 import { useTheme } from "../theme";
@@ -11,7 +11,22 @@ export default function Header({ onMenuClick }: Props) {
   const { BRAND_NAME, LOGO_URL } = useConfig();
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
   const { theme, toggleTheme } = useTheme();
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (
+        menuOpen &&
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node)
+      ) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [menuOpen]);
 
   return (
     <header className="flex items-center justify-between p-4">
@@ -41,7 +56,7 @@ export default function Header({ onMenuClick }: Props) {
         >
           {theme === "light" ? "🌙" : "☀️"}
         </button>
-        <div className="user-menu relative">
+        <div className="user-menu relative" ref={menuRef}>
           <button
             className="icon-button"
             onClick={() => setMenuOpen((o) => !o)}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -76,9 +76,9 @@ export default function Sidebar({ currentId, isOpen, onClose }: Props) {
   return (
     <nav
       className={clsx(
-        'fixed inset-y-0 left-0 w-64 transform transition-transform duration-200 bg-gray-800 p-4 flex flex-col z-20 md:static md:translate-x-0 md:flex',
+        'fixed inset-y-0 left-0 w-64 transform transition-transform duration-200 bg-gray-800 p-4 flex flex-col md:static md:translate-x-0 md:flex',
         isOpen
-          ? 'translate-x-0 pointer-events-auto'
+          ? 'translate-x-0 pointer-events-auto z-20'
           : '-translate-x-full pointer-events-none'
       )}
       aria-label="Histórico de conversas"

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -76,7 +76,7 @@ header .brand {
   display: flex;
   flex-direction: column;
   min-width: 8rem;
-  z-index: 10;
+  z-index: 30;
 }
 
 .user-menu .menu a {


### PR DESCRIPTION
## Summary
- ensure closed sidebar doesn't overlay header
- close user menu on outside click and raise its z-index
- add test for header menu outside-click behavior

## Testing
- `npx vitest run`
- `pytest tests/test_chat.py`


------
https://chatgpt.com/codex/tasks/task_e_68abb3138d2c83239741854a179549ff