### PR TITLE
fix: polyfill crypto.randomUUID usage in frontend

### DIFF
--- a/frontend/src/ChatPage.tsx
+++ b/frontend/src/ChatPage.tsx
@@ -8,6 +8,7 @@ import Disclaimer from './components/Disclaimer';
 import ErrorBanner from './components/ErrorBanner';
 import Sidebar from './components/Sidebar';
 import { ChatProvider, useChat } from './chat';
+import { generateUUID } from './utils/uuid';
 
 interface ConversationMeta {
   id: string;
@@ -52,7 +53,7 @@ export default function ChatPage() {
       localStorage.getItem('conversations') || '[]'
     );
     if (!id || id === 'new') {
-      const newId = crypto.randomUUID();
+      const newId = generateUUID();
       const conv: ConversationMeta = {
         id: newId,
         title: 'Novo chat',

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
+import { generateUUID } from '../utils/uuid';
 
 interface ConversationMeta {
   id: string;
@@ -33,7 +34,7 @@ export default function Sidebar({ currentId, isOpen, onClose }: Props) {
   };
 
   const createNew = () => {
-    const id = crypto.randomUUID();
+    const id = generateUUID();
     const conv: ConversationMeta = {
       id,
       title: 'Novo chat',

--- a/frontend/src/utils/uuid.ts
+++ b/frontend/src/utils/uuid.ts
@@ -1,0 +1,31 @@
+export function generateUUID(): string {
+  // Prefer native crypto.randomUUID if available
+  if (typeof globalThis.crypto !== 'undefined') {
+    if (typeof globalThis.crypto.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID();
+    }
+    if (typeof globalThis.crypto.getRandomValues === 'function') {
+      const arr = new Uint8Array(16);
+      globalThis.crypto.getRandomValues(arr);
+      // RFC4122 version 4
+      arr[6] = (arr[6] & 0x0f) | 0x40;
+      arr[8] = (arr[8] & 0x3f) | 0x80;
+      const toHex = (n: number) => n.toString(16).padStart(2, '0');
+      const h = Array.from(arr, toHex).join('');
+      return `${h.substring(0,8)}-${h.substring(8,12)}-${h.substring(12,16)}-${h.substring(16,20)}-${h.substring(20)}`;
+    }
+  }
+  // Fallback - not cryptographically strong
+  let uuid = '';
+  for (let i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) {
+      uuid += '-';
+    } else if (i === 14) {
+      uuid += '4';
+    } else {
+      const r = Math.random() * 16 | 0;
+      uuid += (i === 19 ? (r & 0x3) | 0x8 : r).toString(16);
+    }
+  }
+  return uuid;
+}


### PR DESCRIPTION
## Summary
- add generateUUID helper with fallback when `crypto.randomUUID` is unavailable
- use generateUUID in ChatPage and Sidebar to create conversation IDs

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb77a971083239cb694d82dc623cf