### PR TITLE
Pin fastembed to v0.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ psycopg[binary]>=3.1
 pgvector>=0.2.5
 pypdf>=4.2
 python-dotenv>=1.0
-fastembed>=0.3.3
+fastembed==0.5.1
 tqdm>=4.66
 fastapi>=0.110
 sse-starlette>=1.6


### PR DESCRIPTION
## Summary
- Pin fastembed dependency to version 0.5.1

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb9c7b7088323b46905f3df8b5107