### PR TITLE
feat: register CLS-pooled multilingual embedding

### DIFF
--- a/app/ingestion/service.py
+++ b/app/ingestion/service.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 import requests
 from bs4 import BeautifulSoup
 from fastembed import TextEmbedding
+import embedding  # registers custom CLS-pooled model
 from pdf2image import convert_from_path
 from pypdf import PdfReader
 import pytesseract
@@ -23,7 +24,7 @@ from .models import Job, JobLogSlice, JobStatus, SourceType
 from .runner import IngestionRunner
 
 # Multilingual embedding model
-EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+EMBEDDING_MODEL = "paraphrase-multilingual-MiniLM-L12-v2-cls"
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schema.sql"
 
 # ---------------------------------------------------------------------------
@@ -292,7 +293,7 @@ def ingest_local(path: Path, *, use_ocr: bool = False, ocr_lang: str | None = No
                     )
                     return
 
-                embedder = TextEmbedding(model_name=EMBEDDING_MODEL)
+                embedder = TextEmbedding(model_name="paraphrase-multilingual-MiniLM-L12-v2-cls")
                 embeddings: list[list[float]] = []
                 for emb in embedder.embed(chunks):
                     if cancel_event.is_set():
@@ -365,7 +366,7 @@ def ingest_urls(urls: List[str]) -> uuid.UUID:
                     log_path=str(log_path),
                 )
 
-                embedder = TextEmbedding(model_name=EMBEDDING_MODEL)
+                embedder = TextEmbedding(model_name="paraphrase-multilingual-MiniLM-L12-v2-cls")
 
                 for url in urls:
                     if cancel_event.is_set():

--- a/app/rag.py
+++ b/app/rag.py
@@ -2,10 +2,11 @@ import os
 import psycopg
 from pgvector.psycopg import register_vector
 from fastembed import TextEmbedding
+import embedding  # registers custom CLS-pooled model
 from typing import List, Tuple, Dict
 
 # Use a supported multilingual embedding model
-embedder = TextEmbedding(model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
+embedder = TextEmbedding(model_name="paraphrase-multilingual-MiniLM-L12-v2-cls")
 
 
 def get_conn():

--- a/embedding.py
+++ b/embedding.py
@@ -1,0 +1,33 @@
+"""Custom fastembed model registration."""
+
+try:  # fastembed >=0.8 exposes ``add_custom_model``
+    from fastembed import add_custom_model  # type: ignore
+except Exception:  # pragma: no cover - fallback for older versions
+    from fastembed import TextEmbedding
+    from fastembed.common.model_description import PoolingType
+
+    def add_custom_model(*, name: str, base: str, pooling: str) -> None:
+        base_info = next(
+            (m for m in TextEmbedding._list_supported_models() if m.model.lower() == base.lower()),
+            None,
+        )
+        if base_info is None:
+            raise ValueError(f"Base model {base} not found")
+        TextEmbedding.add_custom_model(
+            model=name,
+            pooling=PoolingType[pooling.upper()],
+            normalization=True,
+            sources=base_info.sources,
+            dim=base_info.dim,
+            model_file=base_info.model_file,
+            description=base_info.description,
+            license=base_info.license,
+            size_in_gb=base_info.size_in_GB,
+            additional_files=base_info.additional_files,
+        )
+
+add_custom_model(
+    name="paraphrase-multilingual-MiniLM-L12-v2-cls",
+    base="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+    pooling="cls",
+)

--- a/query.py
+++ b/query.py
@@ -7,6 +7,7 @@ import psycopg
 from pgvector.psycopg import register_vector
 
 from fastembed import TextEmbedding
+import embedding  # registers custom CLS-pooled model
 
 from langdetect import detect
 
@@ -61,7 +62,7 @@ def main():
     register_vector(conn)
 
     # Use a supported multilingual embedding model
-    embedder = TextEmbedding(model_name="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
+    embedder = TextEmbedding(model_name="paraphrase-multilingual-MiniLM-L12-v2-cls")
     qvec = list(embedder.embed([f'query: {args.q}']))[0]  # E5 prefix para consulta
 
     sql = """


### PR DESCRIPTION
## Summary
- register custom `paraphrase-multilingual-MiniLM-L12-v2-cls` fastembed model
- use the custom CLS-pooled model throughout RAG, query CLI, and ingestion service

## Testing
- `pytest`
- `python - <<'PY'
import warnings
import embedding
from fastembed import TextEmbedding
with warnings.catch_warnings(record=True) as w:
    embedder = TextEmbedding(model_name="paraphrase-multilingual-MiniLM-L12-v2-cls", lazy_load=True)
    print('warning_count', len(w))
    print('dim', len(next(embedder.embed(['ok']))))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68abbbc8b2788323ae15904ab7262dba