### PR TITLE
feat: allow renaming conversations in sidebar

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -46,13 +46,14 @@ export default function Sidebar({ currentId, isOpen, onClose }: Props) {
   };
 
   const rename = (id: string) => {
-    const title = prompt('Novo título?');
-    if (title) {
-      const list = conversations.map((c) =>
-        c.id === id ? { ...c, title } : c
-      );
-      persist(list);
-    }
+    const current = conversations.find((c) => c.id === id);
+    const title = prompt('Novo título?', current?.title);
+    if (!title) return;
+
+    const updated = conversations.map((c) =>
+      c.id === id ? { ...c, title } : c
+    );
+    persist(updated);
   };
 
   const remove = (id: string) => {


### PR DESCRIPTION
## Summary
- add rename function for conversations in sidebar
- persist updated titles to localStorage and state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abbf4f69808323a22132976d201474