### PR TITLE
feat: make system prompt configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,7 @@ ADMIN_UI_ORIGINS=
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-3.5-turbo
 OPENAI_LANG=
+SYSTEM_PROMPT=
 
 # ---------------------------------------------------------------------------
 # Branding

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Principais chaves disponíveis:
 
 - **PGHOST**, **PGPORT**, **PGDATABASE**, **PGUSER**, **PGPASSWORD** – conexão com o Postgres/pgvector (padrões: `db`, `5432`, `pdfkb`, `pdfkb`, `pdfkb`).
 - **DOCS_DIR** – pasta padrão para os arquivos. Qualquer `.md` nessa pasta é ingerido junto com os PDFs.
-  - **OPENAI_API_KEY**, **OPENAI_MODEL**, **OPENAI_LANG**, **USE_LLM** – integrações com LLM (opcional).
+  - **OPENAI_API_KEY**, **OPENAI_MODEL**, **OPENAI_LANG**, **SYSTEM_PROMPT**, **USE_LLM** – integrações com LLM (opcional). `SYSTEM_PROMPT` permite configurar o tom/persona do agente.
 - **TOP_K**, **MAX_CONTEXT_CHARS** – ajustes de recuperação de trechos.
 - **UPLOAD_DIR**, **UPLOAD_TTL**, **UPLOAD_MAX_SIZE**, **UPLOAD_MAX_FILES**, **UPLOAD_ALLOWED_MIME_TYPES** – controle de uploads temporários.
 - **CORS_ALLOW_ORIGINS**, **BRAND_NAME**, **POWERED_BY_LABEL**, **LOGO_URL** – personalização da UI. `POWERED_BY_LABEL` define o texto do rodapé (padrão: "Powered by PDF Knowledge Kit").

--- a/app/main.py
+++ b/app/main.py
@@ -112,12 +112,16 @@ def _answer_with_context(question: str, context: str) -> tuple[str, bool]:
     )
     if client:
         try:  # pragma: no cover - openai optional
+            base_prompt = "Answer the user's question using the supplied context."
+            custom_prompt = os.getenv("SYSTEM_PROMPT")
+            system_prompt = f"{custom_prompt} {base_prompt}" if custom_prompt else base_prompt
+            system_prompt = f"{system_prompt} {lang_instruction}"
             completion = client.chat.completions.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
                 messages=[
                     {
                         "role": "system",
-                        "content": f"Answer the user's question using the supplied context. {lang_instruction}",
+                        "content": system_prompt,
                     },
                     {
                         "role": "user",
@@ -278,12 +282,16 @@ async def chat_stream(
                 lang_instruction = (
                     f"Reply in {lang}." if lang else "Reply in the same language as the question."
                 )
+                base_prompt = "Answer the user's question using the supplied context."
+                custom_prompt = os.getenv("SYSTEM_PROMPT")
+                system_prompt = f"{custom_prompt} {base_prompt}" if custom_prompt else base_prompt
+                system_prompt = f"{system_prompt} {lang_instruction}"
                 completion = client.chat.completions.create(
                     model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
                     messages=[
                         {
                             "role": "system",
-                            "content": f"Answer the user's question using the supplied context. {lang_instruction}",
+                            "content": system_prompt,
                         },
                         {
                             "role": "user",

--- a/query.py
+++ b/query.py
@@ -32,12 +32,16 @@ def _answer_with_context(question: str, context: str) -> str:
             lang_instruction = (
                 f"Reply in {lang}." if lang else "Reply in the same language as the question."
             )
+            base_prompt = "Answer the user's question using the supplied context."
+            custom_prompt = os.getenv("SYSTEM_PROMPT")
+            system_prompt = f"{custom_prompt} {base_prompt}" if custom_prompt else base_prompt
+            system_prompt = f"{system_prompt} {lang_instruction}"
             completion = client.chat.completions.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
                 messages=[
                     {
                         "role": "system",
-                        "content": f"Answer the user's question using the supplied context. {lang_instruction}",
+                        "content": system_prompt,
                     },
                     {
                         "role": "user",

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -69,3 +69,32 @@ def test_ask_with_llm(client):
     assert data["used_llm"] is True
     assert data["sources"]
     assert dummy_client.messages[0]["content"] == "Answer the user's question using the supplied context. Reply in en."
+
+
+def test_ask_with_custom_system_prompt(client, monkeypatch):
+    class DummyCompletion:
+        def __init__(self):
+            self.choices = [types.SimpleNamespace(message={"content": "llm"})]
+
+    class DummyClient:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self.create))
+            self.messages = None
+
+        def create(self, **kwargs):
+            self.messages = kwargs.get("messages")
+            return DummyCompletion()
+
+    dummy_client = DummyClient()
+    monkeypatch.setenv("SYSTEM_PROMPT", "You are a helper.")
+    with patch("app.main.build_context", dummy_build_context), patch("app.main.client", dummy_client), patch("app.main.detect", lambda _: "en"):
+        resp = client.post("/api/ask", json={"q": "hi", "k": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == "llm"
+    assert data["used_llm"] is True
+    assert data["sources"]
+    assert (
+        dummy_client.messages[0]["content"]
+        == "You are a helper. Answer the user's question using the supplied context. Reply in en."
+    )


### PR DESCRIPTION
## Summary
- allow overriding LLM system prompt via `SYSTEM_PROMPT`
- document new `SYSTEM_PROMPT` setting
- add tests for custom system prompt handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abc2b908f48323bd62df52b9d82f4e