### PR TITLE
Use docker compose for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,12 +2,10 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
 	"name": "Existing Dockerfile",
-	"build": {
-		// Sets the run context to one level up instead of the .devcontainer folder.
-		"context": "..",
-		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-		"dockerfile": "../Dockerfile"
-	},
+        "dockerComposeFile": ["../docker-compose.yml"],
+        "service": "app",
+        "workspaceFolder": "/app",
+        "forwardPorts": [8000,5432,5678],
 	"features": {
 		"ghcr.io/devcontainers/features/python:1": {
 			"installTools": true,


### PR DESCRIPTION
## Summary
- replace Dockerfile build config with docker-compose setup for devcontainer

## Testing
- `pytest` *(fails: ImportError: cannot import name 'PoolingType')*

------
https://chatgpt.com/codex/tasks/task_e_68c070431f6c832389731fe0f34617cc