### PR TITLE
feat: enable debugpy debugging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
         condition: service_healthy
     env_file:
       - .env
+    command: >
+      python -m debugpy --listen 0.0.0.0:5678 --wait-for-client
+      -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
     expose:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ tqdm>=4.66
 fastapi>=0.110
 sse-starlette>=1.6
 uvicorn>=0.29
+debugpy>=1.8
 openai>=1.0
 python-multipart>=0.0.7
 pytest>=8.0


### PR DESCRIPTION
## Summary
- enable remote debugging for app via debugpy
- add debugpy dependency for server

## Testing
- `pip install -r requirements.txt`
- `pytest` (fails: ImportError: cannot import name 'add_custom_model' from 'fastembed')
- `docker compose build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c0711b6bdc832389a540701eeb617a