### PR TITLE
Add VSCode launch configuration for FastAPI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "configurations": [
+    {
+      "name": "Attach to FastAPI",
+      "type": "python",
+      "request": "attach",
+      "connect": {"host": "localhost", "port": 5678},
+      "justMyCode": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `.vscode/launch.json` for attaching a debugger to FastAPI

## Testing
- `pytest` *(fails: ImportError: cannot import name 'PoolingType' from fastembed)*

------
https://chatgpt.com/codex/tasks/task_e_68c071c484b8832391f06cda4eb7b8e3