### PR TITLE
Add agent management APIs and admin UI

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,0 +1,10 @@
+"""Agent management service layer."""
+
+from . import schemas
+from .service import AgentService, create_postgres_service
+
+__all__ = [
+    "AgentService",
+    "create_postgres_service",
+    "schemas",
+]

--- a/app/agents/prompts.py
+++ b/app/agents/prompts.py
@@ -1,0 +1,60 @@
+"""Prompt template helpers for the agent service."""
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+
+class PromptTemplateStore:
+    """Resolve prompt templates based on agent persona and provider."""
+
+    _DEFAULT_TEMPLATES: Mapping[str, Mapping[str, str]] = {
+        "general": {
+            "default": "You are a helpful general-purpose assistant. Be concise and friendly.",
+            "anthropic": "You are an insightful assistant. Provide balanced and thoughtful answers.",
+        },
+        "support": {
+            "default": "You are a customer support agent. Empathise, clarify the issue and provide steps to resolve it.",
+        },
+        "sales": {
+            "default": "You are a persuasive sales assistant. Qualify the lead and highlight product value with warmth.",
+        },
+        "hr": {
+            "default": "You are an HR assistant. Provide policy guidance with empathy and clarity.",
+        },
+    }
+
+    def __init__(self, extra_templates: Optional[Mapping[str, Mapping[str, str]]] = None):
+        self._templates: Dict[str, Dict[str, str]] = {
+            key: dict(value) for key, value in self._DEFAULT_TEMPLATES.items()
+        }
+        if extra_templates:
+            for persona, mapping in extra_templates.items():
+                merged = self._templates.setdefault(persona, {})
+                merged.update(mapping)
+
+    def resolve(self, persona: Optional[Dict[str, Any]], provider: str, custom_template: Optional[str]) -> str:
+        """Return the prompt template for the persona/provider combination."""
+
+        if custom_template:
+            return custom_template
+        persona_type = (persona or {}).get("type") or (persona or {}).get("persona") or "general"
+        persona_type = str(persona_type).lower()
+        provider_key = provider.lower()
+        persona_templates = self._templates.get(persona_type)
+        if persona_templates:
+            if provider_key in persona_templates:
+                return persona_templates[provider_key]
+            if "default" in persona_templates:
+                return persona_templates["default"]
+        fallback = self._templates["general"]
+        return fallback.get(provider_key) or fallback["default"]
+
+    def render(self, base_template: str, persona: Optional[Dict[str, Any]], user_input: str) -> str:
+        """Render the final prompt for preview/testing."""
+
+        persona_instructions = ""
+        if persona:
+            traits = ", ".join(f"{k}: {v}" for k, v in persona.items() if k != "type")
+            if traits:
+                persona_instructions = f"\nPersona traits: {traits}"
+        return f"{base_template}\nUser input: {user_input}{persona_instructions}".strip()

--- a/app/agents/providers.py
+++ b/app/agents/providers.py
@@ -1,0 +1,74 @@
+"""Provider credential helpers supporting multiple LLM vendors."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class ProviderCredentials:
+    """Container for credentials resolved for a provider."""
+
+    provider: str
+    api_key: Optional[str]
+    extras: Dict[str, str]
+
+    def as_headers(self) -> Dict[str, str]:
+        """Return HTTP headers suitable for calling the provider API."""
+
+        headers: Dict[str, str] = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        for key, value in self.extras.items():
+            headers[key] = value
+        return headers
+
+
+class ProviderRegistry:
+    """Resolve provider credentials from environment or explicit overrides."""
+
+    _DEFAULT_ENV_MAP: Mapping[str, str] = {
+        "openai": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "google": "GOOGLE_API_KEY",
+        "meta": "META_API_KEY",
+        "azure": "AZURE_OPENAI_API_KEY",
+    }
+
+    def __init__(self, overrides: Optional[Mapping[str, Mapping[str, str]]] = None):
+        self._overrides = {
+            (k.lower() if isinstance(k, str) else k): dict(v)
+            for k, v in (overrides or {}).items()
+        }
+
+    def get_credentials(self, provider: str) -> ProviderCredentials:
+        """Return credentials for ``provider``.
+
+        The lookup order prefers explicit overrides (e.g. injected during
+        testing) and falls back to environment variables using
+        ``_DEFAULT_ENV_MAP``.
+        """
+
+        key = provider.lower()
+        if key in self._overrides:
+            override = self._overrides[key]
+            return ProviderCredentials(
+                provider=provider,
+                api_key=override.get("api_key"),
+                extras={k: v for k, v in override.items() if k != "api_key"},
+            )
+        env_var = self._DEFAULT_ENV_MAP.get(key)
+        api_key = os.getenv(env_var) if env_var else None
+        extras: Dict[str, str] = {}
+        if key == "azure":
+            endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+            if endpoint:
+                extras["X-API-Endpoint"] = endpoint
+        return ProviderCredentials(provider=provider, api_key=api_key, extras=extras)
+
+    def list_supported_providers(self) -> Dict[str, Optional[str]]:
+        """Return a mapping of supported providers to resolved API keys."""
+
+        providers = set(self._DEFAULT_ENV_MAP.keys()) | set(self._overrides.keys())
+        return {name: self.get_credentials(name).api_key for name in sorted(providers)}

--- a/app/agents/responses.py
+++ b/app/agents/responses.py
@@ -1,0 +1,39 @@
+"""Response parameter defaults for agent executions."""
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+
+class ResponseParameterStore:
+    """Maintain provider specific response parameter defaults."""
+
+    _DEFAULTS: Mapping[str, Dict[str, Any]] = {
+        "openai": {"temperature": 0.7, "max_tokens": 1024},
+        "anthropic": {"temperature": 0.2, "max_tokens": 2048},
+        "google": {"temperature": 0.3, "candidate_count": 1},
+        "meta": {"temperature": 0.6},
+        "azure": {"temperature": 0.65, "max_tokens": 1024},
+    }
+
+    def __init__(self, overrides: Optional[Mapping[str, Mapping[str, Any]]] = None):
+        self._defaults: Dict[str, Dict[str, Any]] = {
+            provider: dict(params) for provider, params in self._DEFAULTS.items()
+        }
+        if overrides:
+            for provider, params in overrides.items():
+                merged = self._defaults.setdefault(provider.lower(), {})
+                merged.update(params)
+
+    def defaults_for_provider(self, provider: str) -> Dict[str, Any]:
+        """Return defaults for ``provider``."""
+
+        return dict(self._defaults.get(provider.lower(), {"temperature": 0.5}))
+
+    def merge(self, provider: str, *overrides: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Merge multiple overrides on top of provider defaults."""
+
+        params = self.defaults_for_provider(provider)
+        for override in overrides:
+            if override:
+                params.update(override)
+        return params

--- a/app/agents/schemas.py
+++ b/app/agents/schemas.py
@@ -1,0 +1,164 @@
+"""Pydantic schemas for agent management APIs."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AgentBase(BaseModel):
+    """Base configuration shared by create/update operations."""
+
+    name: str
+    description: Optional[str] = None
+    provider: str
+    model: str
+    persona: Dict[str, Any] = Field(default_factory=dict)
+    prompt_template: Optional[str] = None
+    response_parameters: Dict[str, Any] = Field(default_factory=dict)
+    deployment_metadata: Dict[str, Any] = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)
+    is_active: bool = True
+    created_by: Optional[str] = None
+    persona_type: Optional[str] = None
+
+
+class AgentCreate(AgentBase):
+    """Payload used to create a new agent."""
+
+    initial_version_label: Optional[str] = None
+
+
+class AgentUpdate(BaseModel):
+    """Patchable agent fields."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    persona: Optional[Dict[str, Any]] = None
+    prompt_template: Optional[str] = None
+    response_parameters: Optional[Dict[str, Any]] = None
+    deployment_metadata: Optional[Dict[str, Any]] = None
+    tags: Optional[List[str]] = None
+    is_active: Optional[bool] = None
+    persona_type: Optional[str] = None
+    created_by: Optional[str] = None
+
+
+class AgentVersionConfig(BaseModel):
+    provider: str
+    model: str
+    persona: Dict[str, Any] = Field(default_factory=dict)
+    prompt_template: Optional[str] = None
+    response_parameters: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentVersion(BaseModel):
+    id: int
+    agent_id: int
+    version: int
+    label: Optional[str] = None
+    created_by: Optional[str] = None
+    config: AgentVersionConfig
+    prompt_template: Optional[str] = None
+    persona: Dict[str, Any] = Field(default_factory=dict)
+    response_parameters: Dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+
+
+class Agent(BaseModel):
+    id: int
+    slug: str
+    name: str
+    description: Optional[str] = None
+    provider: str
+    model: str
+    persona: Dict[str, Any] = Field(default_factory=dict)
+    prompt_template: Optional[str] = None
+    response_parameters: Dict[str, Any] = Field(default_factory=dict)
+    deployment_metadata: Dict[str, Any] = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+    latest_version: Optional[AgentVersion] = None
+
+
+class AgentDetail(Agent):
+    versions: List[AgentVersion] = Field(default_factory=list)
+    tests: List["AgentTestRecord"] = Field(default_factory=list)
+
+
+class AgentVersionCreate(BaseModel):
+    label: Optional[str] = None
+    created_by: Optional[str] = None
+    config: AgentVersionConfig
+
+
+class AgentVersionList(BaseModel):
+    items: List[AgentVersion]
+    total: int
+
+
+class AgentList(BaseModel):
+    items: List[Agent]
+    total: int
+
+
+class AgentTestRequest(BaseModel):
+    input: str = Field(..., description="Prompt to send to the agent")
+    channel: Optional[str] = None
+    response_overrides: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentTestRecord(BaseModel):
+    id: int
+    agent_id: int
+    agent_version_id: Optional[int] = None
+    input_prompt: str
+    response: Dict[str, Any] = Field(default_factory=dict)
+    metrics: Dict[str, Any] = Field(default_factory=dict)
+    status: str
+    channel: Optional[str] = None
+    ran_at: datetime
+
+
+class AgentTestRecordCreate(BaseModel):
+    agent_id: int
+    agent_version_id: Optional[int] = None
+    input_prompt: str
+    response: Dict[str, Any] = Field(default_factory=dict)
+    metrics: Dict[str, Any] = Field(default_factory=dict)
+    status: str = "success"
+    channel: Optional[str] = None
+
+
+class AgentTestResponse(BaseModel):
+    status: str
+    output: str
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+    rendered_prompt: str
+    record: AgentTestRecord
+
+
+class AgentDeployRequest(BaseModel):
+    environment: str
+    endpoint_url: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentDeployResponse(AgentDetail):
+    pass
+
+
+class Message(BaseModel):
+    message: str
+
+try:  # Pydantic v2
+    AgentDetail.model_rebuild()
+    AgentTestResponse.model_rebuild()
+except AttributeError:  # pragma: no cover - Pydantic v1 fallback
+    AgentDetail.update_forward_refs()
+    AgentTestResponse.update_forward_refs()

--- a/app/agents/service.py
+++ b/app/agents/service.py
@@ -1,0 +1,790 @@
+"""Service layer orchestrating agent CRUD, testing and deployment."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import re
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Protocol
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from . import schemas
+from .providers import ProviderRegistry
+from .prompts import PromptTemplateStore
+from .responses import ResponseParameterStore
+
+
+class AgentNotFoundError(RuntimeError):
+    """Raised when an agent could not be located."""
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.lower()).strip("-")
+    return slug or "agent"
+
+
+class AgentRepository(Protocol):
+    """Persistence abstraction used by :class:`AgentService`."""
+
+    def list_agents(self) -> List[schemas.Agent]: ...
+
+    def get_agent(
+        self, agent_id: int, *, include_versions: bool = False, include_tests: bool = False
+    ) -> Optional[schemas.AgentDetail]: ...
+
+    def create_agent(self, payload: schemas.AgentCreate) -> schemas.Agent: ...
+
+    def update_agent(self, agent_id: int, payload: schemas.AgentUpdate) -> schemas.Agent: ...
+
+    def delete_agent(self, agent_id: int) -> None: ...
+
+    def create_version(self, agent_id: int, payload: schemas.AgentVersionCreate) -> schemas.AgentVersion: ...
+
+    def list_versions(self, agent_id: int) -> List[schemas.AgentVersion]: ...
+
+    def latest_version(self, agent_id: int) -> Optional[schemas.AgentVersion]: ...
+
+    def record_test(self, payload: schemas.AgentTestRecordCreate) -> schemas.AgentTestRecord: ...
+
+    def list_tests(self, agent_id: int, limit: int = 20) -> List[schemas.AgentTestRecord]: ...
+
+    def update_deployment_metadata(self, agent_id: int, metadata: Dict[str, Any]) -> schemas.Agent: ...
+
+
+class AgentService:
+    """High-level orchestration for managing agents."""
+
+    def __init__(
+        self,
+        repository: AgentRepository,
+        provider_registry: Optional[ProviderRegistry] = None,
+        prompt_store: Optional[PromptTemplateStore] = None,
+        response_store: Optional[ResponseParameterStore] = None,
+    ) -> None:
+        self._repository = repository
+        self._providers = provider_registry or ProviderRegistry()
+        self._prompts = prompt_store or PromptTemplateStore()
+        self._responses = response_store or ResponseParameterStore()
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+
+    def list_agents(self) -> List[schemas.Agent]:
+        return self._repository.list_agents()
+
+    def get_agent(self, agent_id: int) -> schemas.AgentDetail:
+        agent = self._repository.get_agent(agent_id, include_versions=True, include_tests=True)
+        if not agent:
+            raise AgentNotFoundError(f"Agent {agent_id} not found")
+        return agent
+
+    def create_agent(self, payload: schemas.AgentCreate) -> schemas.AgentDetail:
+        persona = dict(payload.persona or {})
+        if payload.persona_type:
+            persona.setdefault("type", payload.persona_type)
+        persona.setdefault("type", persona.get("type", "general"))
+        prompt_template = self._prompts.resolve(persona, payload.provider, payload.prompt_template)
+        response_parameters = self._responses.merge(payload.provider, payload.response_parameters)
+        credentials = self._providers.get_credentials(payload.provider)
+        cleaned_payload = _normalise_create_payload(
+            payload,
+            persona,
+            prompt_template,
+            response_parameters,
+            bool(credentials.api_key),
+        )
+        agent = self._repository.create_agent(cleaned_payload)
+        version_config = schemas.AgentVersionConfig(
+            provider=agent.provider,
+            model=agent.model,
+            persona=agent.persona,
+            prompt_template=agent.prompt_template,
+            response_parameters=agent.response_parameters,
+        )
+        version_payload = schemas.AgentVersionCreate(
+            label=payload.initial_version_label or "v1",
+            created_by=payload.created_by,
+            config=version_config,
+        )
+        version = self._repository.create_version(agent.id, version_payload)
+        agent.latest_version = version
+        return self.get_agent(agent.id)
+
+    def update_agent(self, agent_id: int, payload: schemas.AgentUpdate) -> schemas.AgentDetail:
+        existing = self._repository.get_agent(agent_id)
+        if not existing:
+            raise AgentNotFoundError(f"Agent {agent_id} not found")
+        persona = dict(payload.persona or existing.persona)
+        if payload.persona_type:
+            persona.setdefault("type", payload.persona_type)
+        prompt_template = self._prompts.resolve(
+            persona,
+            payload.provider or existing.provider,
+            payload.prompt_template or existing.prompt_template,
+        )
+        response_parameters = self._responses.merge(
+            payload.provider or existing.provider,
+            existing.response_parameters,
+            payload.response_parameters,
+        )
+        credentials = self._providers.get_credentials(payload.provider or existing.provider)
+        merged_payload = _normalise_update_payload(
+            payload,
+            persona,
+            prompt_template,
+            response_parameters,
+            bool(credentials.api_key),
+            existing.deployment_metadata,
+        )
+        self._repository.update_agent(agent_id, merged_payload)
+        return self.get_agent(agent_id)
+
+    def delete_agent(self, agent_id: int) -> None:
+        self._repository.delete_agent(agent_id)
+
+    # ------------------------------------------------------------------
+    # Versions
+
+    def create_version(self, agent_id: int, payload: schemas.AgentVersionCreate) -> schemas.AgentVersion:
+        existing = self._repository.get_agent(agent_id)
+        if not existing:
+            raise AgentNotFoundError(f"Agent {agent_id} not found")
+        version = self._repository.create_version(agent_id, payload)
+        return version
+
+    def list_versions(self, agent_id: int) -> List[schemas.AgentVersion]:
+        return self._repository.list_versions(agent_id)
+
+    # ------------------------------------------------------------------
+    # Testing & deployment
+
+    def run_test(self, agent_id: int, request: schemas.AgentTestRequest) -> schemas.AgentTestResponse:
+        agent = self._repository.get_agent(agent_id)
+        if not agent:
+            raise AgentNotFoundError(f"Agent {agent_id} not found")
+        latest_version = agent.latest_version or self._repository.latest_version(agent_id)
+        parameters = self._responses.merge(agent.provider, agent.response_parameters, request.response_overrides)
+        prompt_template = agent.prompt_template or self._prompts.resolve(agent.persona, agent.provider, None)
+        rendered_prompt = self._prompts.render(prompt_template, agent.persona, request.input)
+        credentials = self._providers.get_credentials(agent.provider)
+        # Sandboxed execution: we don't call real LLMs in tests, instead echo behaviour.
+        output = _simulate_model_response(agent.name, rendered_prompt, parameters)
+        record_payload = schemas.AgentTestRecordCreate(
+            agent_id=agent.id,
+            agent_version_id=latest_version.id if latest_version else None,
+            input_prompt=request.input,
+            response={"text": output},
+            metrics={
+                "provider": agent.provider,
+                "temperature": parameters.get("temperature"),
+                "credential_present": bool(credentials.api_key),
+            },
+            status="success",
+            channel=request.channel,
+        )
+        record = self._repository.record_test(record_payload)
+        return schemas.AgentTestResponse(
+            status="success",
+            output=output,
+            parameters=parameters,
+            rendered_prompt=rendered_prompt,
+            record=record,
+        )
+
+    def deploy_agent(self, agent_id: int, request: schemas.AgentDeployRequest) -> schemas.AgentDetail:
+        agent = self._repository.get_agent(agent_id)
+        if not agent:
+            raise AgentNotFoundError(f"Agent {agent_id} not found")
+        metadata = dict(agent.deployment_metadata)
+        environments = metadata.setdefault("environments", {})
+        environments[request.environment] = {
+            "endpoint_url": request.endpoint_url,
+            "metadata": request.metadata,
+            "deployed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        updated_agent = self._repository.update_deployment_metadata(agent_id, metadata)
+        return self.get_agent(updated_agent.id)
+
+    def list_tests(self, agent_id: int, limit: int = 20) -> List[schemas.AgentTestRecord]:
+        return self._repository.list_tests(agent_id, limit=limit)
+
+    def list_supported_providers(self) -> Dict[str, Optional[str]]:
+        return self._providers.list_supported_providers()
+
+
+def _simulate_model_response(name: str, rendered_prompt: str, parameters: Dict[str, Any]) -> str:
+    preview = rendered_prompt.splitlines()[-1] if rendered_prompt else ""
+    return f"Agent {name} (temp={parameters.get('temperature')}) would reply to: {preview}"
+
+
+def _normalise_create_payload(
+    payload: schemas.AgentCreate,
+    persona: Dict[str, Any],
+    prompt_template: str,
+    response_parameters: Dict[str, Any],
+    credentials_available: bool,
+) -> schemas.AgentCreate:
+    data = _model_dump(payload, exclude={"initial_version_label"})
+    data.update(
+        {
+            "persona": persona,
+            "prompt_template": prompt_template,
+            "response_parameters": response_parameters,
+            "deployment_metadata": data.get("deployment_metadata") or {},
+            "tags": data.get("tags") or [],
+        }
+    )
+    metadata = dict(data["deployment_metadata"])
+    metadata.setdefault("provider_credentials", {})
+    metadata["provider_credentials"]["configured"] = credentials_available
+    data["deployment_metadata"] = metadata
+    return schemas.AgentCreate(**data)
+
+
+def _normalise_update_payload(
+    payload: schemas.AgentUpdate,
+    persona: Dict[str, Any],
+    prompt_template: str,
+    response_parameters: Dict[str, Any],
+    credentials_available: Optional[bool],
+    existing_metadata: Optional[Dict[str, Any]],
+) -> schemas.AgentUpdate:
+    data = _model_dump(payload)
+    if payload.persona is not None or payload.persona_type is not None:
+        data["persona"] = persona
+    data["prompt_template"] = prompt_template
+    data["response_parameters"] = response_parameters
+    metadata = dict(existing_metadata or {})
+    if "deployment_metadata" in data:
+        incoming = data["deployment_metadata"] or {}
+        metadata.update(incoming)
+        data["deployment_metadata"] = metadata
+    elif credentials_available is not None:
+        metadata.setdefault("provider_credentials", {})
+        metadata["provider_credentials"]["configured"] = credentials_available
+        data["deployment_metadata"] = metadata
+    if "deployment_metadata" not in data:
+        data["deployment_metadata"] = metadata
+    if "tags" in data and data["tags"] is None:
+        data["tags"] = []
+    return schemas.AgentUpdate(**data)
+
+
+def _model_dump(model: Any, exclude: Optional[Iterable[str]] = None) -> Dict[str, Any]:
+    exclude = set(exclude or [])
+    if hasattr(model, "model_dump"):
+        return {
+            k: v
+            for k, v in model.model_dump().items()
+            if k not in exclude and v is not None
+        }
+    return {k: v for k, v in model.dict().items() if k not in exclude and v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Postgres repository implementation
+
+
+@dataclass
+class _ConnectionWrapper:
+    conn: psycopg.Connection
+
+    def cursor(self):
+        return self.conn.cursor(row_factory=dict_row)
+
+
+class PostgresAgentRepository:
+    """PostgreSQL-backed agent repository."""
+
+    def __init__(self, connection: psycopg.Connection):
+        self._conn = connection
+
+    def cursor(self):
+        return self._conn.cursor(row_factory=dict_row)
+
+    def list_agents(self) -> List[schemas.Agent]:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, slug, name, description, provider, model, persona, prompt_template,
+                       response_params, deployment_metadata, tags, is_active, created_at, updated_at
+                FROM agents
+                ORDER BY name
+                """
+            )
+            rows = cur.fetchall()
+        agents = [self._row_to_agent(row) for row in rows]
+        for agent in agents:
+            agent.latest_version = self.latest_version(agent.id)
+        return agents
+
+    def get_agent(
+        self, agent_id: int, *, include_versions: bool = False, include_tests: bool = False
+    ) -> Optional[schemas.AgentDetail]:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, slug, name, description, provider, model, persona, prompt_template,
+                       response_params, deployment_metadata, tags, is_active, created_at, updated_at
+                FROM agents
+                WHERE id = %s
+                """,
+                (agent_id,),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None
+        agent = self._row_to_agent(row)
+        detail = schemas.AgentDetail(**agent.model_dump())
+        if include_versions:
+            detail.versions = self.list_versions(agent_id)
+            detail.latest_version = detail.versions[-1] if detail.versions else None
+        else:
+            detail.latest_version = self.latest_version(agent_id)
+        if include_tests:
+            detail.tests = self.list_tests(agent_id)
+        return detail
+
+    def create_agent(self, payload: schemas.AgentCreate) -> schemas.Agent:
+        with self.cursor() as cur:
+            slug = self._generate_unique_slug(cur, payload.name)
+            cur.execute(
+                """
+                INSERT INTO agents
+                    (slug, name, description, provider, model, persona, prompt_template,
+                     response_params, deployment_metadata, tags, is_active)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id, slug, name, description, provider, model, persona, prompt_template,
+                          response_params, deployment_metadata, tags, is_active, created_at, updated_at
+                """,
+                (
+                    slug,
+                    payload.name,
+                    payload.description,
+                    payload.provider,
+                    payload.model,
+                    Jsonb(payload.persona),
+                    payload.prompt_template,
+                    Jsonb(payload.response_parameters),
+                    Jsonb(payload.deployment_metadata or {}),
+                    payload.tags,
+                    payload.is_active,
+                ),
+            )
+            row = cur.fetchone()
+        agent = self._row_to_agent(row)
+        return agent
+
+    def _generate_unique_slug(self, cur, name: str) -> str:
+        base = _slugify(name)
+        candidate = base
+        suffix = 1
+        while True:
+            cur.execute("SELECT 1 FROM agents WHERE slug = %s", (candidate,))
+            if cur.fetchone() is None:
+                return candidate
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+
+    def update_agent(self, agent_id: int, payload: schemas.AgentUpdate) -> schemas.Agent:
+        fields: List[str] = []
+        values: List[Any] = []
+        data = _model_dump(payload)
+        for key, value in data.items():
+            if key == "persona":
+                fields.append("persona = %s")
+                values.append(Jsonb(value))
+            elif key == "response_parameters":
+                fields.append("response_params = %s")
+                values.append(Jsonb(value))
+            elif key == "deployment_metadata":
+                fields.append("deployment_metadata = %s")
+                values.append(Jsonb(value))
+            elif key == "prompt_template":
+                fields.append("prompt_template = %s")
+                values.append(value)
+            elif key == "tags":
+                fields.append("tags = %s")
+                values.append(value)
+            elif key == "persona_type":
+                continue
+            else:
+                fields.append(f"{key} = %s")
+                values.append(value)
+        if not fields:
+            agent = self.get_agent(agent_id)
+            if not agent:
+                raise AgentNotFoundError
+            return agent
+        set_clause = ", ".join(fields)
+        query = f"UPDATE agents SET {set_clause} WHERE id = %s RETURNING id, slug, name, description, provider, model, persona, prompt_template, response_params, deployment_metadata, tags, is_active, created_at, updated_at"
+        values.append(agent_id)
+        with self.cursor() as cur:
+            cur.execute(query, values)
+            row = cur.fetchone()
+        if not row:
+            raise AgentNotFoundError
+        return self._row_to_agent(row)
+
+    def delete_agent(self, agent_id: int) -> None:
+        with self.cursor() as cur:
+            cur.execute("DELETE FROM agents WHERE id = %s", (agent_id,))
+
+    def create_version(self, agent_id: int, payload: schemas.AgentVersionCreate) -> schemas.AgentVersion:
+        latest = self.latest_version(agent_id)
+        next_version = (latest.version + 1) if latest else 1
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO agent_versions
+                    (agent_id, version, label, created_by, config, prompt_template, persona, response_params)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id, agent_id, version, label, created_by, config, prompt_template, persona, response_params, created_at
+                """,
+                (
+                    agent_id,
+                    next_version,
+                    payload.label,
+                    payload.created_by,
+                    Jsonb(payload.config.model_dump()),
+                    payload.config.prompt_template,
+                    Jsonb(payload.config.persona),
+                    Jsonb(payload.config.response_parameters),
+                ),
+            )
+            row = cur.fetchone()
+        version = self._row_to_version(row)
+        return version
+
+    def list_versions(self, agent_id: int) -> List[schemas.AgentVersion]:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, agent_id, version, label, created_by, config, prompt_template, persona, response_params, created_at
+                FROM agent_versions
+                WHERE agent_id = %s
+                ORDER BY version
+                """,
+                (agent_id,),
+            )
+            rows = cur.fetchall()
+        return [self._row_to_version(row) for row in rows]
+
+    def latest_version(self, agent_id: int) -> Optional[schemas.AgentVersion]:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, agent_id, version, label, created_by, config, prompt_template, persona, response_params, created_at
+                FROM agent_versions
+                WHERE agent_id = %s
+                ORDER BY version DESC
+                LIMIT 1
+                """,
+                (agent_id,),
+            )
+            row = cur.fetchone()
+        return self._row_to_version(row) if row else None
+
+    def record_test(self, payload: schemas.AgentTestRecordCreate) -> schemas.AgentTestRecord:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO agent_tests
+                    (agent_version_id, agent_id, input_prompt, response, metrics, status, channel)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                RETURNING id, agent_version_id, agent_id, input_prompt, response, metrics, status, channel, ran_at
+                """,
+                (
+                    payload.agent_version_id,
+                    payload.agent_id,
+                    payload.input_prompt,
+                    Jsonb(payload.response),
+                    Jsonb(payload.metrics),
+                    payload.status,
+                    payload.channel,
+                ),
+            )
+            row = cur.fetchone()
+        return self._row_to_test(row)
+
+    def list_tests(self, agent_id: int, limit: int = 20) -> List[schemas.AgentTestRecord]:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, agent_version_id, agent_id, input_prompt, response, metrics, status, channel, ran_at
+                FROM agent_tests
+                WHERE agent_id = %s
+                ORDER BY ran_at DESC
+                LIMIT %s
+                """,
+                (agent_id, limit),
+            )
+            rows = cur.fetchall()
+        return [self._row_to_test(row) for row in rows]
+
+    def update_deployment_metadata(self, agent_id: int, metadata: Dict[str, Any]) -> schemas.Agent:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE agents
+                SET deployment_metadata = %s
+                WHERE id = %s
+                RETURNING id, slug, name, description, provider, model, persona, prompt_template,
+                          response_params, deployment_metadata, tags, is_active, created_at, updated_at
+                """,
+                (Jsonb(metadata), agent_id),
+            )
+            row = cur.fetchone()
+        if not row:
+            raise AgentNotFoundError
+        return self._row_to_agent(row)
+
+    # ------------------------------------------------------------------
+    # Row converters
+
+    def _row_to_agent(self, row: Dict[str, Any]) -> schemas.Agent:
+        return schemas.Agent(
+            id=row["id"],
+            slug=row["slug"],
+            name=row["name"],
+            description=row.get("description"),
+            provider=row["provider"],
+            model=row["model"],
+            persona=row.get("persona") or {},
+            prompt_template=row.get("prompt_template"),
+            response_parameters=row.get("response_params") or {},
+            deployment_metadata=row.get("deployment_metadata") or {},
+            tags=list(row.get("tags") or []),
+            is_active=row.get("is_active", True),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            latest_version=None,
+        )
+
+    def _row_to_version(self, row: Dict[str, Any]) -> schemas.AgentVersion:
+        config = row.get("config") or {}
+        return schemas.AgentVersion(
+            id=row["id"],
+            agent_id=row["agent_id"],
+            version=row["version"],
+            label=row.get("label"),
+            created_by=row.get("created_by"),
+            config=schemas.AgentVersionConfig(
+                provider=config.get("provider", ""),
+                model=config.get("model", ""),
+                persona=config.get("persona") or {},
+                prompt_template=config.get("prompt_template"),
+                response_parameters=config.get("response_parameters") or {},
+            ),
+            prompt_template=row.get("prompt_template"),
+            persona=row.get("persona") or {},
+            response_parameters=row.get("response_params") or {},
+            created_at=row["created_at"],
+        )
+
+    def _row_to_test(self, row: Dict[str, Any]) -> schemas.AgentTestRecord:
+        return schemas.AgentTestRecord(
+            id=row["id"],
+            agent_id=row["agent_id"],
+            agent_version_id=row.get("agent_version_id"),
+            input_prompt=row["input_prompt"],
+            response=row.get("response") or {},
+            metrics=row.get("metrics") or {},
+            status=row.get("status", "success"),
+            channel=row.get("channel"),
+            ran_at=row["ran_at"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# In-memory repository (useful for testing and sandbox environments)
+
+
+class InMemoryAgentRepository(AgentRepository):
+    def __init__(self) -> None:
+        self._agents: Dict[int, schemas.AgentDetail] = {}
+        self._versions: Dict[int, List[schemas.AgentVersion]] = {}
+        self._tests: Dict[int, List[schemas.AgentTestRecord]] = {}
+        self._agent_id_seq = 1
+        self._version_id_seq = 1
+        self._test_id_seq = 1
+
+    def list_agents(self) -> List[schemas.Agent]:
+        agents = [schemas.Agent(**agent.model_dump()) for agent in self._agents.values()]
+        for agent in agents:
+            versions = self._versions.get(agent.id, [])
+            agent.latest_version = versions[-1] if versions else None
+        agents.sort(key=lambda a: a.name)
+        return agents
+
+    def get_agent(
+        self, agent_id: int, *, include_versions: bool = False, include_tests: bool = False
+    ) -> Optional[schemas.AgentDetail]:
+        agent = self._agents.get(agent_id)
+        if not agent:
+            return None
+        clone = schemas.AgentDetail(**agent.model_dump())
+        if include_versions:
+            clone.versions = list(self._versions.get(agent_id, []))
+            clone.latest_version = clone.versions[-1] if clone.versions else None
+        else:
+            versions = self._versions.get(agent_id, [])
+            clone.latest_version = versions[-1] if versions else None
+        if include_tests:
+            clone.tests = list(self._tests.get(agent_id, []))
+        return clone
+
+    def create_agent(self, payload: schemas.AgentCreate) -> schemas.Agent:
+        agent_id = self._agent_id_seq
+        self._agent_id_seq += 1
+        now = datetime.now(timezone.utc)
+        slug = self._make_unique_slug(payload.name)
+        detail = schemas.AgentDetail(
+            id=agent_id,
+            slug=slug,
+            name=payload.name,
+            description=payload.description,
+            provider=payload.provider,
+            model=payload.model,
+            persona=payload.persona,
+            prompt_template=payload.prompt_template,
+            response_parameters=payload.response_parameters,
+            deployment_metadata=payload.deployment_metadata or {},
+            tags=payload.tags or [],
+            is_active=payload.is_active,
+            created_at=now,
+            updated_at=now,
+            versions=[],
+            tests=[],
+            latest_version=None,
+        )
+        self._agents[agent_id] = detail
+        return schemas.Agent(**detail.model_dump())
+
+    def _make_unique_slug(self, name: str, exclude_id: Optional[int] = None) -> str:
+        base = _slugify(name)
+        slug = base
+        suffix = 1
+        used = {agent.slug for aid, agent in self._agents.items() if aid != exclude_id}
+        while slug in used:
+            slug = f"{base}-{suffix}"
+            suffix += 1
+        return slug
+
+    def update_agent(self, agent_id: int, payload: schemas.AgentUpdate) -> schemas.Agent:
+        agent = self._agents.get(agent_id)
+        if not agent:
+            raise AgentNotFoundError
+        data = _model_dump(payload)
+        for key, value in data.items():
+            if key == "persona":
+                agent.persona = value
+            elif key == "prompt_template":
+                agent.prompt_template = value
+            elif key == "response_parameters":
+                agent.response_parameters = value
+            elif key == "deployment_metadata":
+                agent.deployment_metadata = value or {}
+            elif key == "tags":
+                agent.tags = value or []
+            elif key == "is_active":
+                agent.is_active = bool(value)
+            elif key == "name":
+                agent.name = value
+                agent.slug = self._make_unique_slug(value, exclude_id=agent_id)
+            elif key == "description":
+                agent.description = value
+            elif key == "provider":
+                agent.provider = value
+            elif key == "model":
+                agent.model = value
+        agent.updated_at = datetime.now(timezone.utc)
+        self._agents[agent_id] = agent
+        return schemas.Agent(**agent.model_dump())
+
+    def delete_agent(self, agent_id: int) -> None:
+        self._agents.pop(agent_id, None)
+        self._versions.pop(agent_id, None)
+        self._tests.pop(agent_id, None)
+
+    def create_version(self, agent_id: int, payload: schemas.AgentVersionCreate) -> schemas.AgentVersion:
+        versions = self._versions.setdefault(agent_id, [])
+        version_number = versions[-1].version + 1 if versions else 1
+        version = schemas.AgentVersion(
+            id=self._version_id_seq,
+            agent_id=agent_id,
+            version=version_number,
+            label=payload.label,
+            created_by=payload.created_by,
+            config=payload.config,
+            prompt_template=payload.config.prompt_template,
+            persona=payload.config.persona,
+            response_parameters=payload.config.response_parameters,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._version_id_seq += 1
+        versions.append(version)
+        agent = self._agents.get(agent_id)
+        if agent:
+            agent.latest_version = version
+        return version
+
+    def list_versions(self, agent_id: int) -> List[schemas.AgentVersion]:
+        return list(self._versions.get(agent_id, []))
+
+    def latest_version(self, agent_id: int) -> Optional[schemas.AgentVersion]:
+        versions = self._versions.get(agent_id, [])
+        return versions[-1] if versions else None
+
+    def record_test(self, payload: schemas.AgentTestRecordCreate) -> schemas.AgentTestRecord:
+        record = schemas.AgentTestRecord(
+            id=self._test_id_seq,
+            agent_id=payload.agent_id,
+            agent_version_id=payload.agent_version_id,
+            input_prompt=payload.input_prompt,
+            response=payload.response,
+            metrics=payload.metrics,
+            status=payload.status,
+            channel=payload.channel,
+            ran_at=datetime.now(timezone.utc),
+        )
+        self._test_id_seq += 1
+        self._tests.setdefault(payload.agent_id, []).insert(0, record)
+        return record
+
+    def list_tests(self, agent_id: int, limit: int = 20) -> List[schemas.AgentTestRecord]:
+        return list(self._tests.get(agent_id, []))[:limit]
+
+    def update_deployment_metadata(self, agent_id: int, metadata: Dict[str, Any]) -> schemas.Agent:
+        agent = self._agents.get(agent_id)
+        if not agent:
+            raise AgentNotFoundError
+        agent.deployment_metadata = metadata
+        agent.updated_at = datetime.now(timezone.utc)
+        return schemas.Agent(**agent.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# Service factory helpers
+
+
+def create_postgres_service(connection: psycopg.Connection) -> AgentService:
+    repository = PostgresAgentRepository(connection)
+    return AgentService(repository)
+
+
+@contextmanager
+def service_context_from_dsn(dsn: str) -> Iterator[AgentService]:
+    conn = psycopg.connect(dsn)
+    try:
+        service = create_postgres_service(conn)
+        yield service
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()

--- a/app/main.py
+++ b/app/main.py
@@ -45,7 +45,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from .rag import build_context
 from .sse_utils import sse_word_buffer
 from .app_logging import init_logging
-from .routers import admin_ingest_api, auth_api, feedback_api
+from .routers import admin_ingest_api, auth_api, feedback_api, agents
 
 try:
     from openai import OpenAI
@@ -100,6 +100,7 @@ app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR), name="uploads")
 app.include_router(admin_ingest_api.router)
 app.include_router(auth_api.router)
 app.include_router(feedback_api.router)
+app.include_router(agents.router)
  
 # Expose Prometheus metrics
 Instrumentator().instrument(app).expose(

--- a/app/routers/agents.py
+++ b/app/routers/agents.py
@@ -1,0 +1,139 @@
+"""Agent management API router."""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ..agents import schemas
+from ..agents.service import (
+    AgentNotFoundError,
+    AgentService,
+    PostgresAgentRepository,
+)
+from ..security.auth import require_role
+
+router = APIRouter(prefix="/api/agents", tags=["agents"])
+
+_DATABASE_URL = os.getenv("DATABASE_URL")
+
+
+def _get_conn() -> psycopg.Connection:
+    if not _DATABASE_URL:
+        raise HTTPException(status_code=500, detail="DATABASE_URL not configured")
+    try:
+        return psycopg.connect(_DATABASE_URL)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@contextmanager
+def _service_context() -> Iterator[AgentService]:
+    conn = _get_conn()
+    repo = PostgresAgentRepository(conn)
+    service = AgentService(repo)
+    try:
+        yield service
+        conn.commit()
+    except AgentNotFoundError as exc:
+        conn.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        conn.rollback()
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        conn.close()
+
+
+@router.get("", response_model=schemas.AgentList)
+def list_agents(role: str = Depends(require_role("viewer"))) -> schemas.AgentList:
+    with _service_context() as svc:
+        agents = svc.list_agents()
+    return schemas.AgentList(items=agents, total=len(agents))
+
+
+@router.get("/providers", response_model=dict[str, str | None])
+def list_providers(role: str = Depends(require_role("viewer"))) -> dict[str, str | None]:
+    with _service_context() as svc:
+        return svc.list_supported_providers()
+
+
+@router.post("", response_model=schemas.AgentDetail, status_code=status.HTTP_201_CREATED)
+def create_agent(
+    payload: schemas.AgentCreate,
+    role: str = Depends(require_role("operator")),
+) -> schemas.AgentDetail:
+    with _service_context() as svc:
+        return svc.create_agent(payload)
+
+
+@router.get("/{agent_id}", response_model=schemas.AgentDetail)
+def get_agent(agent_id: int, role: str = Depends(require_role("viewer"))) -> schemas.AgentDetail:
+    with _service_context() as svc:
+        return svc.get_agent(agent_id)
+
+
+@router.put("/{agent_id}", response_model=schemas.AgentDetail)
+def update_agent(
+    agent_id: int,
+    payload: schemas.AgentUpdate,
+    role: str = Depends(require_role("operator")),
+) -> schemas.AgentDetail:
+    with _service_context() as svc:
+        return svc.update_agent(agent_id, payload)
+
+
+@router.delete("/{agent_id}", response_model=schemas.Message)
+def delete_agent(agent_id: int, role: str = Depends(require_role("operator"))) -> schemas.Message:
+    with _service_context() as svc:
+        svc.delete_agent(agent_id)
+    return schemas.Message(message="deleted")
+
+
+@router.get("/{agent_id}/versions", response_model=schemas.AgentVersionList)
+def list_versions(agent_id: int, role: str = Depends(require_role("viewer"))) -> schemas.AgentVersionList:
+    with _service_context() as svc:
+        versions = svc.list_versions(agent_id)
+    return schemas.AgentVersionList(items=versions, total=len(versions))
+
+
+@router.post("/{agent_id}/versions", response_model=schemas.AgentVersion, status_code=status.HTTP_201_CREATED)
+def create_version(
+    agent_id: int,
+    payload: schemas.AgentVersionCreate,
+    role: str = Depends(require_role("operator")),
+) -> schemas.AgentVersion:
+    with _service_context() as svc:
+        return svc.create_version(agent_id, payload)
+
+
+@router.post("/{agent_id}/test", response_model=schemas.AgentTestResponse)
+def test_agent(
+    agent_id: int,
+    payload: schemas.AgentTestRequest,
+    role: str = Depends(require_role("operator")),
+) -> schemas.AgentTestResponse:
+    with _service_context() as svc:
+        return svc.run_test(agent_id, payload)
+
+
+@router.get("/{agent_id}/tests", response_model=list[schemas.AgentTestRecord])
+def list_tests(agent_id: int, role: str = Depends(require_role("viewer"))):
+    with _service_context() as svc:
+        return svc.list_tests(agent_id)
+
+
+@router.post("/{agent_id}/deploy", response_model=schemas.AgentDeployResponse)
+def deploy_agent(
+    agent_id: int,
+    payload: schemas.AgentDeployRequest,
+    role: str = Depends(require_role("operator")),
+) -> schemas.AgentDeployResponse:
+    with _service_context() as svc:
+        return svc.deploy_agent(agent_id, payload)

--- a/frontend/src/admin/AdminApp.tsx
+++ b/frontend/src/admin/AdminApp.tsx
@@ -6,6 +6,7 @@ import IngestUrl from './IngestUrl';
 import IngestUrls from './IngestUrls';
 import JobDetail from './JobDetail';
 import Sources from './Sources';
+import AgentBuilder from './AgentBuilder';
 
 export default function AdminApp() {
   return (
@@ -17,6 +18,7 @@ export default function AdminApp() {
           <li><Link to="/admin/ingest/url">Single URL</Link></li>
           <li><Link to="/admin/ingest/urls">Multiple URLs</Link></li>
           <li><Link to="/admin/sources">Sources</Link></li>
+          <li><Link to="/admin/agents">Agents</Link></li>
         </ul>
       </nav>
       <Routes>
@@ -26,6 +28,7 @@ export default function AdminApp() {
         <Route path="ingest/urls" element={<IngestUrls />} />
         <Route path="jobs/:id" element={<JobDetail />} />
         <Route path="sources" element={<Sources />} />
+        <Route path="agents" element={<AgentBuilder />} />
       </Routes>
     </div>
   );

--- a/frontend/src/admin/AgentBuilder.tsx
+++ b/frontend/src/admin/AgentBuilder.tsx
@@ -1,0 +1,468 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useApiFetch } from '../apiKey';
+import useAuth from '../hooks/useAuth';
+
+interface AgentSummary {
+  id: number;
+  name: string;
+  provider: string;
+  model: string;
+  description?: string;
+  latest_version?: { version: number } | null;
+}
+
+interface AgentVersion {
+  id: number;
+  agent_id: number;
+  version: number;
+  label?: string | null;
+  created_by?: string | null;
+  created_at: string;
+}
+
+interface AgentTestRecord {
+  id: number;
+  input_prompt: string;
+  status: string;
+  ran_at: string;
+  response: { text?: string };
+}
+
+interface AgentDetail extends AgentSummary {
+  slug: string;
+  persona: Record<string, any>;
+  prompt_template?: string | null;
+  response_parameters: Record<string, any>;
+  deployment_metadata: Record<string, any>;
+  tags: string[];
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  versions?: AgentVersion[];
+  tests?: AgentTestRecord[];
+}
+
+interface AgentListResponse {
+  items: AgentSummary[];
+  total: number;
+}
+
+interface AgentTestResponse {
+  status: string;
+  output: string;
+  rendered_prompt: string;
+  parameters: Record<string, any>;
+  record: AgentTestRecord;
+}
+
+interface AgentFormState {
+  name: string;
+  description: string;
+  provider: string;
+  model: string;
+  personaType: string;
+  personaTone: string;
+  personaStyle: string;
+  promptTemplate: string;
+  temperature: number;
+}
+
+const defaultForm: AgentFormState = {
+  name: '',
+  description: '',
+  provider: 'openai',
+  model: 'gpt-4o-mini',
+  personaType: 'general',
+  personaTone: 'friendly',
+  personaStyle: 'concise',
+  promptTemplate: '',
+  temperature: 0.7,
+};
+
+function detailToForm(detail: AgentDetail): AgentFormState {
+  return {
+    name: detail.name,
+    description: detail.description || '',
+    provider: detail.provider,
+    model: detail.model,
+    personaType: (detail.persona && (detail.persona.type || detail.persona.persona)) || 'general',
+    personaTone: detail.persona?.tone || '',
+    personaStyle: detail.persona?.style || '',
+    promptTemplate: detail.prompt_template || '',
+    temperature: Number(detail.response_parameters?.temperature ?? 0.7),
+  };
+}
+
+export default function AgentBuilder() {
+  const apiFetch = useApiFetch();
+  const { roles } = useAuth();
+  const canOperate = roles.includes('operator') || roles.includes('admin');
+
+  const [agents, setAgents] = useState<AgentSummary[]>([]);
+  const [providers, setProviders] = useState<string[]>([]);
+  const [selectedAgent, setSelectedAgent] = useState<AgentDetail | null>(null);
+  const [form, setForm] = useState<AgentFormState>(defaultForm);
+  const [loading, setLoading] = useState(false);
+  const [testInput, setTestInput] = useState('Hello! How can you help me today?');
+  const [testResult, setTestResult] = useState<AgentTestResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const environments = useMemo(() => {
+    return (
+      (selectedAgent?.deployment_metadata?.environments as Record<string, any>) || {}
+    );
+  }, [selectedAgent]);
+
+  useEffect(() => {
+    loadProviders();
+    loadAgents();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const loadAgents = async () => {
+    try {
+      const res = await apiFetch('/api/agents');
+      if (!res.ok) throw new Error('Failed to load agents');
+      const data = (await res.json()) as AgentListResponse;
+      setAgents(data.items || []);
+    } catch {
+      setAgents([]);
+    }
+  };
+
+  const loadProviders = async () => {
+    try {
+      const res = await apiFetch('/api/agents/providers');
+      if (!res.ok) throw new Error('Failed to load providers');
+      const data = (await res.json()) as Record<string, string | null>;
+      setProviders(Object.keys(data));
+    } catch {
+      setProviders(['openai', 'anthropic', 'google', 'meta']);
+    }
+  };
+
+  const resetForm = () => {
+    setSelectedAgent(null);
+    setForm(defaultForm);
+    setTestResult(null);
+  };
+
+  const selectAgent = async (agentId: number) => {
+    setError(null);
+    try {
+      const res = await apiFetch(`/api/agents/${agentId}`);
+      if (!res.ok) throw new Error('Failed to load agent');
+      const data = (await res.json()) as AgentDetail;
+      setSelectedAgent(data);
+      setForm(detailToForm(data));
+      setTestResult(null);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const buildPayload = () => {
+    const persona: Record<string, string> = {
+      type: form.personaType,
+    };
+    if (form.personaTone) persona.tone = form.personaTone;
+    if (form.personaStyle) persona.style = form.personaStyle;
+    const responseParameters = {
+      temperature: Number.isFinite(form.temperature) ? form.temperature : 0.7,
+    };
+    return { persona, responseParameters };
+  };
+
+  const saveAgent = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    const { persona, responseParameters } = buildPayload();
+    const basePayload = {
+      name: form.name,
+      description: form.description,
+      provider: form.provider,
+      model: form.model,
+      persona,
+      persona_type: form.personaType,
+      prompt_template: form.promptTemplate || undefined,
+      response_parameters: responseParameters,
+      tags: selectedAgent?.tags || [],
+    };
+    try {
+      const res = selectedAgent
+        ? await apiFetch(`/api/agents/${selectedAgent.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(basePayload),
+          })
+        : await apiFetch('/api/agents', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              ...basePayload,
+              initial_version_label: 'v1',
+            }),
+          });
+      if (!res.ok) throw new Error('Unable to save agent');
+      const detail = (await res.json()) as AgentDetail;
+      setSelectedAgent(detail);
+      setForm(detailToForm(detail));
+      await loadAgents();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const runTest = async () => {
+    if (!selectedAgent) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/api/agents/${selectedAgent.id}/test`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ input: testInput }),
+      });
+      if (!res.ok) throw new Error('Failed to run test');
+      const data = (await res.json()) as AgentTestResponse;
+      setTestResult(data);
+      await selectAgent(selectedAgent.id);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const deployAgent = async () => {
+    if (!selectedAgent) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/api/agents/${selectedAgent.id}/deploy`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          environment: 'sandbox',
+          metadata: { triggered_from_ui: true },
+        }),
+      });
+      if (!res.ok) throw new Error('Deployment failed');
+      const data = (await res.json()) as AgentDetail;
+      setSelectedAgent(data);
+      await loadAgents();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFieldChange = (key: keyof AgentFormState) =>
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      const value =
+        key === 'temperature' ? Number(event.target.value) : event.target.value;
+      setForm((prev) => ({ ...prev, [key]: value }));
+    };
+
+  if (!canOperate) {
+    return <p>You do not have permission to manage agents.</p>;
+  }
+
+  return (
+    <div className="agent-builder">
+      <div className="agent-grid">
+        <section aria-label="Agent list">
+          <header className="agent-grid__header">
+            <h2>Agents</h2>
+            <button type="button" onClick={resetForm} aria-label="Create new agent">
+              New Agent
+            </button>
+          </header>
+          {agents.length === 0 ? (
+            <p>No agents created yet.</p>
+          ) : (
+            <ul>
+              {agents.map((agent) => (
+                <li key={agent.id}>
+                  <button
+                    type="button"
+                    onClick={() => selectAgent(agent.id)}
+                    aria-label={`Edit ${agent.name}`}
+                  >
+                    <strong>{agent.name}</strong>
+                    <div className="agent-meta">
+                      {agent.provider} · {agent.model}
+                      {agent.latest_version?.version && (
+                        <span> · v{agent.latest_version.version}</span>
+                      )}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section aria-label="Agent builder form">
+          <h2>{selectedAgent ? `Edit ${selectedAgent.name}` : 'Create new agent'}</h2>
+          {error && <p role="alert">{error}</p>}
+          <form onSubmit={saveAgent} aria-label="Agent configuration form">
+            <label htmlFor="agent-name">Name</label>
+            <input
+              id="agent-name"
+              value={form.name}
+              onChange={handleFieldChange('name')}
+              required
+            />
+
+            <label htmlFor="agent-description">Description</label>
+            <textarea
+              id="agent-description"
+              value={form.description}
+              onChange={handleFieldChange('description')}
+              rows={2}
+            />
+
+            <label htmlFor="agent-provider">Provider</label>
+            <select
+              id="agent-provider"
+              value={form.provider}
+              onChange={handleFieldChange('provider')}
+            >
+              {providers.map((provider) => (
+                <option key={provider} value={provider}>
+                  {provider}
+                </option>
+              ))}
+            </select>
+
+            <label htmlFor="agent-model">Model</label>
+            <input
+              id="agent-model"
+              value={form.model}
+              onChange={handleFieldChange('model')}
+              required
+            />
+
+            <fieldset>
+              <legend>Personality</legend>
+              <label htmlFor="persona-type">Persona Type</label>
+              <select
+                id="persona-type"
+                value={form.personaType}
+                onChange={handleFieldChange('personaType')}
+              >
+                <option value="general">General</option>
+                <option value="support">Support</option>
+                <option value="sales">Sales</option>
+                <option value="hr">HR</option>
+              </select>
+
+              <label htmlFor="persona-tone">Tone</label>
+              <input
+                id="persona-tone"
+                value={form.personaTone}
+                onChange={handleFieldChange('personaTone')}
+              />
+
+              <label htmlFor="persona-style">Style</label>
+              <input
+                id="persona-style"
+                value={form.personaStyle}
+                onChange={handleFieldChange('personaStyle')}
+              />
+            </fieldset>
+
+            <label htmlFor="prompt-template">Prompt Template</label>
+            <textarea
+              id="prompt-template"
+              value={form.promptTemplate}
+              onChange={handleFieldChange('promptTemplate')}
+              rows={4}
+              placeholder="Provide custom system instructions or leave blank for defaults"
+            />
+
+            <label htmlFor="temperature">Temperature</label>
+            <input
+              id="temperature"
+              type="number"
+              step="0.1"
+              min="0"
+              max="1.5"
+              value={form.temperature}
+              onChange={handleFieldChange('temperature')}
+            />
+
+            <button type="submit" disabled={loading}>
+              {selectedAgent ? 'Update agent' : 'Create agent'}
+            </button>
+          </form>
+
+          {selectedAgent && (
+            <div className="agent-status">
+              <h3>Deployment</h3>
+              <p>
+                Provider credentials:{' '}
+                {selectedAgent.deployment_metadata?.provider_credentials?.configured
+                  ? 'configured'
+                  : 'missing'}
+              </p>
+              {Object.keys(environments).length > 0 ? (
+                <ul>
+                  {Object.entries(environments).map(([env, info]) => (
+                    <li key={env}>
+                      <strong>{env}</strong>: {info.endpoint_url || 'no endpoint'}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p>No deployments yet.</p>
+              )}
+            </div>
+          )}
+        </section>
+
+        <section aria-label="Sandbox tester">
+          <h2>Sandbox tester</h2>
+          <textarea
+            aria-label="Test prompt"
+            value={testInput}
+            onChange={(e) => setTestInput(e.target.value)}
+            rows={4}
+          />
+          <div className="sandbox-actions">
+            <button type="button" onClick={runTest} disabled={!selectedAgent || loading}>
+              Run test
+            </button>
+            <button type="button" onClick={deployAgent} disabled={!selectedAgent || loading}>
+              Deploy to sandbox
+            </button>
+          </div>
+          {testResult && (
+            <div role="status" className="test-result">
+              <h3>Latest test</h3>
+              <p>{testResult.output}</p>
+              <pre>{testResult.rendered_prompt}</pre>
+            </div>
+          )}
+          {selectedAgent?.tests && selectedAgent.tests.length > 0 && (
+            <div className="test-history">
+              <h3>Test history</h3>
+              <ul>
+                {selectedAgent.tests.map((record) => (
+                  <li key={record.id}>
+                    {new Date(record.ran_at).toLocaleString()}: {record.status}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/admin/__tests__/AgentBuilder.test.tsx
+++ b/frontend/src/admin/__tests__/AgentBuilder.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import 'whatwg-fetch';
+import { beforeAll, afterAll, afterEach, test, expect } from 'vitest';
+
+import { ApiKeyProvider } from '../../apiKey';
+import AgentBuilder from '../AgentBuilder';
+
+interface AgentSummary {
+  id: number;
+  name: string;
+  provider: string;
+  model: string;
+  description?: string;
+  latest_version?: { version: number } | null;
+}
+
+interface AgentDetail extends AgentSummary {
+  slug: string;
+  persona: Record<string, any>;
+  prompt_template?: string | null;
+  response_parameters: Record<string, any>;
+  deployment_metadata: Record<string, any>;
+  tags: string[];
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  versions?: any[];
+  tests?: any[];
+}
+
+let agents: AgentSummary[] = [];
+let agentDetail: AgentDetail | null = null;
+
+const now = () => new Date().toISOString();
+
+const server = setupServer(
+  http.get('/api/auth/roles', () => HttpResponse.json({ roles: ['operator'] })),
+  http.get('/api/agents/providers', () =>
+    HttpResponse.json({ openai: 'key', anthropic: null })
+  ),
+  http.get('/api/agents', () => HttpResponse.json({ items: agents, total: agents.length })),
+  http.post('/api/agents', async ({ request }) => {
+    const payload = (await request.json()) as any;
+    const id = 1;
+    agentDetail = {
+      id,
+      slug: 'support-bot',
+      name: payload.name,
+      description: payload.description,
+      provider: payload.provider,
+      model: payload.model,
+      persona: { ...(payload.persona || {}), type: payload.persona_type || 'general' },
+      prompt_template:
+        payload.prompt_template ||
+        'You are a helpful support agent. Provide empathetic and actionable responses.',
+      response_parameters: payload.response_parameters || { temperature: 0.7 },
+      deployment_metadata: {
+        provider_credentials: { configured: true },
+        environments: {},
+      },
+      tags: [],
+      is_active: true,
+      created_at: now(),
+      updated_at: now(),
+      latest_version: { version: 1 },
+      versions: [
+        {
+          id: 1,
+          agent_id: id,
+          version: 1,
+          label: payload.initial_version_label || 'v1',
+          created_by: 'tester',
+          created_at: now(),
+        },
+      ],
+      tests: [],
+    };
+    agents = [
+      {
+        id,
+        name: payload.name,
+        provider: payload.provider,
+        model: payload.model,
+        description: payload.description,
+        latest_version: { version: 1 },
+      },
+    ];
+    return HttpResponse.json(agentDetail, { status: 201 });
+  }),
+  http.get('/api/agents/:id', () => {
+    if (!agentDetail) {
+      return new HttpResponse(null, { status: 404 });
+    }
+    return HttpResponse.json(agentDetail);
+  }),
+  http.put('/api/agents/:id', async ({ request }) => {
+    if (!agentDetail) return new HttpResponse(null, { status: 404 });
+    const payload = (await request.json()) as any;
+    agentDetail = {
+      ...agentDetail,
+      description: payload.description ?? agentDetail.description,
+      model: payload.model ?? agentDetail.model,
+      prompt_template: payload.prompt_template ?? agentDetail.prompt_template,
+      response_parameters: payload.response_parameters || agentDetail.response_parameters,
+      persona: { ...agentDetail.persona, ...(payload.persona || {}) },
+      updated_at: now(),
+    };
+    agents = agents.map((item) =>
+      item.id === agentDetail!.id
+        ? {
+            ...item,
+            name: agentDetail!.name,
+            description: agentDetail!.description,
+            model: agentDetail!.model,
+          }
+        : item
+    );
+    return HttpResponse.json(agentDetail);
+  }),
+  http.post('/api/agents/:id/test', async ({ request }) => {
+    if (!agentDetail) return new HttpResponse(null, { status: 404 });
+    const payload = (await request.json()) as any;
+    const record = {
+      id: (agentDetail.tests?.length || 0) + 1,
+      input_prompt: payload.input,
+      status: 'success',
+      ran_at: now(),
+      response: { text: `Simulated: ${payload.input}` },
+    };
+    agentDetail = {
+      ...agentDetail,
+      tests: [record, ...(agentDetail.tests || [])],
+    };
+    return HttpResponse.json({
+      status: 'success',
+      output: record.response.text,
+      rendered_prompt: `Rendered prompt for: ${payload.input}`,
+      parameters: agentDetail.response_parameters,
+      record,
+    });
+  }),
+  http.post('/api/agents/:id/deploy', async () => {
+    if (!agentDetail) return new HttpResponse(null, { status: 404 });
+    const environments = {
+      ...(agentDetail.deployment_metadata.environments || {}),
+      sandbox: {
+        endpoint_url: 'https://sandbox.example',
+        deployed_at: now(),
+        metadata: { triggered_from_ui: true },
+      },
+    };
+    agentDetail = {
+      ...agentDetail,
+      deployment_metadata: {
+        ...agentDetail.deployment_metadata,
+        environments,
+      },
+      updated_at: now(),
+    };
+    return HttpResponse.json(agentDetail);
+  })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  agents = [];
+  agentDetail = null;
+  localStorage.clear();
+});
+afterAll(() => server.close());
+
+test('agent builder creates, tests and deploys agents', async () => {
+  localStorage.setItem('apiKey', 'test');
+  render(
+    <ApiKeyProvider>
+      <AgentBuilder />
+    </ApiKeyProvider>
+  );
+
+  await screen.findByLabelText('Name');
+
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Support Bot' } });
+  fireEvent.change(screen.getByLabelText('Description'), {
+    target: { value: 'Handles customer support questions.' },
+  });
+  fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-4o' } });
+  fireEvent.change(screen.getByLabelText('Persona Type'), { target: { value: 'support' } });
+  fireEvent.change(screen.getByLabelText('Tone'), { target: { value: 'warm' } });
+  fireEvent.change(screen.getByLabelText('Style'), { target: { value: 'detailed' } });
+  fireEvent.change(screen.getByLabelText('Prompt Template'), {
+    target: { value: 'Act as a support hero.' },
+  });
+  fireEvent.change(screen.getByLabelText('Temperature'), { target: { value: '0.4' } });
+
+  fireEvent.click(screen.getByRole('button', { name: /create agent/i }));
+
+  await screen.findByRole('button', { name: /edit support bot/i });
+
+  fireEvent.change(screen.getByLabelText('Description'), {
+    target: { value: 'Updated description for the agent.' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /update agent/i }));
+
+  await waitFor(() => {
+    const textarea = screen.getByLabelText('Description') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('Updated description for the agent.');
+  });
+
+  fireEvent.change(screen.getByLabelText('Test prompt'), {
+    target: { value: 'Hello agent' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /run test/i }));
+
+  await screen.findByText(/Simulated: Hello agent/);
+
+  fireEvent.click(screen.getByRole('button', { name: /deploy to sandbox/i }));
+
+  await waitFor(() => {
+    const sandboxLabel = screen.getByText('sandbox', { selector: 'strong' });
+    expect(sandboxLabel.parentElement?.textContent).toContain('https://sandbox.example');
+  });
+});

--- a/migrations/006_add_agent_tables.sql
+++ b/migrations/006_add_agent_tables.sql
@@ -1,0 +1,62 @@
+CREATE TABLE IF NOT EXISTS agents (
+    id BIGSERIAL PRIMARY KEY,
+    slug TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    description TEXT,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    persona JSONB NOT NULL DEFAULT '{}'::jsonb,
+    prompt_template TEXT,
+    response_params JSONB NOT NULL DEFAULT '{}'::jsonb,
+    deployment_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION set_agents_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS agents_updated_at ON agents;
+CREATE TRIGGER agents_updated_at
+BEFORE UPDATE ON agents
+FOR EACH ROW
+EXECUTE PROCEDURE set_agents_updated_at();
+
+CREATE TABLE IF NOT EXISTS agent_versions (
+    id BIGSERIAL PRIMARY KEY,
+    agent_id BIGINT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    label TEXT,
+    created_by TEXT,
+    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    prompt_template TEXT,
+    persona JSONB NOT NULL DEFAULT '{}'::jsonb,
+    response_params JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(agent_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_versions_agent_id ON agent_versions(agent_id);
+
+CREATE TABLE IF NOT EXISTS agent_tests (
+    id BIGSERIAL PRIMARY KEY,
+    agent_version_id BIGINT REFERENCES agent_versions(id) ON DELETE CASCADE,
+    agent_id BIGINT REFERENCES agents(id) ON DELETE CASCADE,
+    input_prompt TEXT NOT NULL,
+    expected_behavior TEXT,
+    response JSONB,
+    metrics JSONB,
+    status TEXT NOT NULL DEFAULT 'pending',
+    channel TEXT,
+    ran_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_tests_agent_id ON agent_tests(agent_id);
+CREATE INDEX IF NOT EXISTS idx_agent_tests_agent_version_id ON agent_tests(agent_version_id);

--- a/tests/test_agents_api.py
+++ b/tests/test_agents_api.py
@@ -1,0 +1,122 @@
+import importlib
+from contextlib import contextmanager
+
+from fastapi.testclient import TestClient
+
+from app.agents import service as agent_service_module
+
+
+def create_client(monkeypatch):
+    monkeypatch.setenv("VIEW_API_KEY", "view")
+    monkeypatch.setenv("OP_API_KEY", "oper")
+    monkeypatch.setenv("ADMIN_API_KEY", "admin")
+
+    import app.routers.agents as agents_router
+    importlib.reload(agents_router)
+
+    provider_registry = agent_service_module.ProviderRegistry({"openai": {"api_key": "test"}})
+    svc = agent_service_module.AgentService(
+        agent_service_module.InMemoryAgentRepository(),
+        provider_registry=provider_registry,
+        prompt_store=agent_service_module.PromptTemplateStore(),
+        response_store=agent_service_module.ResponseParameterStore({"openai": {"temperature": 0.6}}),
+    )
+
+    @contextmanager
+    def fake_context():
+        yield svc
+
+    monkeypatch.setattr(agents_router, "_service_context", fake_context)
+
+    import app.security.auth as auth
+    importlib.reload(auth)
+    import app.main as main
+    importlib.reload(main)
+
+    return TestClient(main.app), svc
+
+
+def test_agent_crud_and_deploy_flow(monkeypatch):
+    client, svc = create_client(monkeypatch)
+
+    create_payload = {
+        "name": "Support Bot",
+        "description": "Helps customers with product questions",
+        "provider": "openai",
+        "model": "gpt-4o",
+        "persona": {"tone": "warm", "style": "detailed"},
+        "persona_type": "support",
+        "response_parameters": {"temperature": 0.4},
+        "initial_version_label": "v1",
+        "tags": ["support"],
+    }
+
+    res = client.post("/api/agents", json=create_payload, headers={"X-API-Key": "oper"})
+    assert res.status_code == 201
+    agent_detail = res.json()
+    agent_id = agent_detail["id"]
+    assert agent_detail["deployment_metadata"]["provider_credentials"]["configured"]
+
+    res = client.get("/api/agents", headers={"X-API-Key": "view"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["total"] == 1
+    assert data["items"][0]["name"] == "Support Bot"
+
+    res = client.get("/api/agents/providers", headers={"X-API-Key": "view"})
+    assert res.status_code == 200
+    providers = res.json()
+    assert "openai" in providers
+
+    update_payload = {
+        "description": "Updated description",
+        "response_parameters": {"temperature": 0.2},
+        "prompt_template": "You are a careful support representative.",
+    }
+    res = client.put(
+        f"/api/agents/{agent_id}",
+        json=update_payload,
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+    updated = res.json()
+    assert updated["description"] == "Updated description"
+    assert updated["response_parameters"]["temperature"] == 0.2
+
+    res = client.get(f"/api/agents/{agent_id}/versions", headers={"X-API-Key": "view"})
+    assert res.status_code == 200
+    versions = res.json()
+    assert versions["total"] == 1
+
+    res = client.post(
+        f"/api/agents/{agent_id}/test",
+        json={"input": "How do I reset my password?"},
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+    test_result = res.json()
+    assert "Agent Support Bot" in test_result["output"]
+
+    res = client.post(
+        f"/api/agents/{agent_id}/deploy",
+        json={"environment": "staging", "metadata": {"requested_by": "qa"}},
+        headers={"X-API-Key": "oper"},
+    )
+    assert res.status_code == 200
+    deployed = res.json()
+    assert deployed["deployment_metadata"]["environments"]["staging"]["metadata"]["requested_by"] == "qa"
+
+    res = client.get(f"/api/agents/{agent_id}/tests", headers={"X-API-Key": "view"})
+    assert res.status_code == 200
+    tests = res.json()
+    assert len(tests) == 1
+
+    res = client.delete(f"/api/agents/{agent_id}", headers={"X-API-Key": "oper"})
+    assert res.status_code == 200
+    assert res.json()["message"] == "deleted"
+
+    res = client.get("/api/agents", headers={"X-API-Key": "view"})
+    assert res.json()["total"] == 0
+
+    # ensure underlying service reflects deletion
+    assert svc.list_agents() == []


### PR DESCRIPTION
## Summary
- add PostgreSQL tables and migrations for agents, versions, and test runs
- build provider-aware agent service layer with FastAPI router endpoints
- extend the admin UI with an agent builder workflow and automated tests

## Testing
- pytest tests/test_agents_api.py
- npm --prefix frontend test -- --run AgentBuilder

------
https://chatgpt.com/codex/tasks/task_e_68dc87fcbff48323876f50c3e881e145