### PR TITLE
Add structured parsers and metadata-aware ingestion pipeline

### DIFF
--- a/.env
+++ b/.env
@@ -52,7 +52,7 @@ ADMIN_UI_ORIGINS=
 # OpenAI
 OPENAI_API_KEY=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
 OPENAI_MODEL=gpt-3.5-turbo
-OPENAI_LANG="pt" 
+OPENAI_LANG=
 
 # ---------------------------------------------------------------------------
 # Branding

--- a/app/ingestion/__init__.py
+++ b/app/ingestion/__init__.py
@@ -1,4 +1,12 @@
 """Ingestion package exposing high level APIs."""
+from .parsers import (
+    Chunk,
+    extract_html_text,
+    read_csv_text,
+    read_docx_text,
+    read_txt_text,
+    read_xlsx_text,
+)
 from .service import (
     read_md_text,
     read_pdf_text,
@@ -20,6 +28,12 @@ from .service import (
 )
 
 __all__ = [
+    "Chunk",
+    "extract_html_text",
+    "read_csv_text",
+    "read_docx_text",
+    "read_txt_text",
+    "read_xlsx_text",
     "read_md_text",
     "read_pdf_text",
     "read_url_text",

--- a/app/ingestion/parsers/__init__.py
+++ b/app/ingestion/parsers/__init__.py
@@ -1,0 +1,20 @@
+"""Helpers for parsing various document formats into text segments."""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from .documents import read_docx_text, read_txt_text, read_csv_text, read_xlsx_text
+from .html import extract_html_text
+from .types import Chunk
+
+ParsedSegment = Tuple[str, Dict[str, object]]
+
+__all__ = [
+    "Chunk",
+    "ParsedSegment",
+    "read_docx_text",
+    "read_txt_text",
+    "read_csv_text",
+    "read_xlsx_text",
+    "extract_html_text",
+]

--- a/app/ingestion/parsers/documents.py
+++ b/app/ingestion/parsers/documents.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from csv import reader as csv_reader
+from csv import Sniffer
+
+try:  # pragma: no cover - optional dependency import
+    from docx import Document  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency import
+    Document = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency import
+    from openpyxl import load_workbook  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency import
+    load_workbook = None  # type: ignore
+
+ParsedSegment = Tuple[str, Dict[str, object]]
+
+
+def _read_text_with_fallbacks(path: Path, encodings: Iterable[str]) -> str:
+    for enc in encodings:
+        try:
+            return path.read_text(encoding=enc)
+        except Exception:
+            continue
+    return path.read_bytes().decode("utf-8", errors="ignore")
+
+
+def read_txt_text(path: Path) -> List[ParsedSegment]:
+    """Read a plain text file returning a single segment with metadata."""
+
+    text = _read_text_with_fallbacks(path, ("utf-8", "utf-8-sig", "latin-1"))
+    return [
+        (
+            text,
+            {
+                "mime_type": "text/plain",
+                "page_number": 1,
+            },
+        )
+    ]
+
+
+def read_docx_text(path: Path) -> List[ParsedSegment]:
+    """Extract text from a DOCX file including paragraphs and tables."""
+
+    if Document is None:
+        raise RuntimeError("python-docx is required to read DOCX files")
+
+    document = Document(str(path))
+    parts: List[str] = []
+
+    for paragraph in document.paragraphs:
+        text = paragraph.text.strip()
+        if text:
+            parts.append(text)
+
+    for table in document.tables:
+        for row in table.rows:
+            cells = [cell.text.strip() for cell in row.cells if cell.text and cell.text.strip()]
+            if cells:
+                parts.append(" | ".join(cells))
+
+    text = "\n\n".join(parts)
+    return [
+        (
+            text,
+            {
+                "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "page_number": 1,
+            },
+        )
+    ]
+
+
+def read_csv_text(path: Path) -> List[ParsedSegment]:
+    """Read a CSV file and return one segment per row."""
+
+    raw = _read_text_with_fallbacks(path, ("utf-8", "utf-8-sig", "latin-1"))
+    lines = raw.splitlines()
+    try:
+        first_line = lines[0]
+    except IndexError:
+        first_line = ""
+    try:
+        dialect = Sniffer().sniff(first_line) if first_line else None
+    except Exception:
+        dialect = None
+
+    segments: List[ParsedSegment] = []
+    for idx, row in enumerate(
+        csv_reader(lines, dialect=dialect) if dialect else csv_reader(lines),
+        start=1,
+    ):
+        row_text = ", ".join(cell.strip() for cell in row if cell.strip())
+        if row_text:
+            segments.append(
+                (
+                    row_text,
+                    {
+                        "mime_type": "text/csv",
+                        "row_number": idx,
+                    },
+                )
+            )
+    return segments or [
+        (
+            raw,
+            {
+                "mime_type": "text/csv",
+            },
+        )
+    ]
+
+
+def read_xlsx_text(path: Path) -> List[ParsedSegment]:
+    """Read an XLSX workbook, returning segments per sheet row."""
+
+    if load_workbook is None:
+        raise RuntimeError("openpyxl is required to read XLSX files")
+
+    workbook = load_workbook(filename=str(path), data_only=True, read_only=True)
+    segments: List[ParsedSegment] = []
+
+    for sheet in workbook.worksheets:
+        for idx, row in enumerate(sheet.iter_rows(values_only=True), start=1):
+            cells = [str(cell).strip() for cell in row if cell is not None and str(cell).strip()]
+            if cells:
+                segments.append(
+                    (
+                        " | ".join(cells),
+                        {
+                            "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                            "sheet_name": sheet.title,
+                            "row_number": idx,
+                        },
+                    )
+                )
+
+    if not segments:
+        segments.append(
+            (
+                "",
+                {
+                    "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                },
+            )
+        )
+    workbook.close()
+    return segments

--- a/app/ingestion/parsers/html.py
+++ b/app/ingestion/parsers/html.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+BLOCK_TAGS = {
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "div",
+    "dl",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "li",
+    "main",
+    "nav",
+    "ol",
+    "p",
+    "pre",
+    "section",
+    "table",
+    "td",
+    "th",
+    "ul",
+}
+
+
+def extract_html_text(html: str) -> str:
+    """Convert HTML into readable text with minimal noise."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "noscript", "template"]):
+        tag.decompose()
+
+    lines = []
+    for element in soup.stripped_strings:
+        parent = getattr(element, "parent", None)
+        if parent and parent.name and parent.name.lower() in BLOCK_TAGS:
+            lines.append(element.strip())
+        else:
+            if lines:
+                lines[-1] = f"{lines[-1]} {element.strip()}".strip()
+            else:
+                lines.append(element.strip())
+    return "\n".join(lines)

--- a/app/ingestion/parsers/types.py
+++ b/app/ingestion/parsers/types.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class Chunk:
+    """Represents a chunk of text plus metadata for ingestion."""
+
+    content: str
+    source_path: str
+    mime_type: str
+    page_number: Optional[int] = None
+    sheet_name: Optional[str] = None
+    row_number: Optional[int] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_metadata(self) -> Dict[str, Any]:
+        """Return a metadata dictionary suitable for persistence."""
+
+        metadata: Dict[str, Any] = {
+            "source_path": self.source_path,
+            "mime_type": self.mime_type,
+            "page_number": self.page_number,
+            "sheet_name": self.sheet_name,
+            "row_number": self.row_number,
+        }
+        if self.extra:
+            metadata.update(self.extra)
+        return {k: v for k, v in metadata.items() if v is not None}

--- a/migrations/007_add_chunk_metadata.sql
+++ b/migrations/007_add_chunk_metadata.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chunks
+    ADD COLUMN IF NOT EXISTS metadata JSONB;

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ beautifulsoup4>=4.12.0
 prometheus-fastapi-instrumentator>=6.0.0
 testing.postgresql
 rank-bm25>=0.2.2
+python-docx>=1.1.0
+openpyxl>=3.1.0

--- a/schema.sql
+++ b/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS chunks (
   chunk_index INT NOT NULL,
   content TEXT NOT NULL,
   token_est INT,
+  metadata JSONB,
   embedding VECTOR(384),
   UNIQUE (doc_id, chunk_index)
 );

--- a/tests/test_ingest_md.py
+++ b/tests/test_ingest_md.py
@@ -17,11 +17,16 @@ def test_read_chunk_embed_markdown(fname, monkeypatch):
     text = ingest.read_md_text(path)
     assert text.strip() != ""
 
-    chunks = ingest.chunk_text(text)
+    chunks = ingest.chunk_text(
+        text,
+        source_path=str(path),
+        mime_type="text/markdown",
+        page_number=1,
+    )
     assert chunks
 
     monkeypatch.setattr(ingest, "TextEmbedding", lambda model_name: DummyEmbedder())
     embedder = ingest.TextEmbedding(model_name=ingest.EMBEDDING_MODEL)
 
-    vectors = list(embedder.embed(chunks))
+    vectors = list(embedder.embed([chunk.content for chunk in chunks]))
     assert len(vectors) == len(chunks)

--- a/tests/test_ingest_url.py
+++ b/tests/test_ingest_url.py
@@ -32,11 +32,16 @@ def test_read_chunk_embed_url(html, monkeypatch):
     text = ingest.read_url_text("http://example.com")
     assert text.strip() != ""
 
-    chunks = ingest.chunk_text(text)
+    chunks = ingest.chunk_text(
+        text,
+        source_path="http://example.com",
+        mime_type="text/html",
+        page_number=1,
+    )
     assert chunks
 
     monkeypatch.setattr(ingest, "TextEmbedding", lambda model_name: DummyEmbedder())
     embedder = ingest.TextEmbedding(model_name=ingest.EMBEDDING_MODEL)
 
-    vectors = list(embedder.embed(chunks))
+    vectors = list(embedder.embed([chunk.content for chunk in chunks]))
     assert len(vectors) == len(chunks)


### PR DESCRIPTION
## Summary
- add a dedicated ingestion.parsers package with helpers for TXT, DOCX, CSV, XLSX, and HTML extraction plus a Chunk dataclass
- refactor ingestion service to emit Chunk metadata, register parsers by file suffix, and persist chunk metadata in Postgres
- expose new helpers via app.ingestion, update schema/migrations, and adjust unit tests for metadata-aware chunking

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc8f26c58883238d5bf937aafae0e8