### PR TITLE
Add connector metadata columns and document version tracking

### DIFF
--- a/app/ingestion/models.py
+++ b/app/ingestion/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Generic, List, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 from uuid import UUID
 
 from pydantic import BaseModel, HttpUrl
@@ -74,6 +74,10 @@ class SourceCreate(BaseModel):
     location: str | None = None
     active: bool = True
     params: dict | None = None
+    connector_type: str | None = None
+    credentials: Any | None = None
+    sync_state: dict | None = None
+    version: int | None = None
 
 
 class SourceUpdate(BaseModel):
@@ -85,6 +89,10 @@ class SourceUpdate(BaseModel):
     location: str | None = None
     active: bool | None = None
     params: dict | None = None
+    connector_type: str | None = None
+    credentials: Any | None = None
+    sync_state: dict | None = None
+    version: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +115,10 @@ class Source(BaseModel):
     url: HttpUrl | None = None
     active: bool = True
     params: dict | None = None
+    connector_type: str | None = None
+    credentials: Any | None = None
+    sync_state: dict | None = None
+    version: int = 1
     created_at: datetime
 
 
@@ -147,4 +159,43 @@ class JobLogSlice(BaseModel):
     content: str
     next_offset: int
     status: JobStatus | None = None
+
+
+class ChunkMetadata(BaseModel):
+    """Structured representation of the metadata stored alongside chunks."""
+
+    source_path: str
+    mime_type: str
+    page_number: int | None = None
+    sheet_name: str | None = None
+    row_number: int | None = None
+    extra: Dict[str, Any] | None = None
+
+    def to_json(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable payload for persistence."""
+
+        payload: Dict[str, Any] = {
+            "source_path": self.source_path,
+            "mime_type": self.mime_type,
+            "page_number": self.page_number,
+            "sheet_name": self.sheet_name,
+            "row_number": self.row_number,
+        }
+        if self.extra:
+            payload.update(self.extra)
+        return {k: v for k, v in payload.items() if v is not None}
+
+
+class DocumentVersion(BaseModel):
+    """Snapshot of a document's metadata for version history APIs."""
+
+    document_id: UUID
+    source_id: UUID | None = None
+    version: int
+    bytes: int | None = None
+    page_count: int | None = None
+    connector_type: str | None = None
+    credentials: Any | None = None
+    sync_state: dict | None = None
+    created_at: datetime
 

--- a/app/ingestion/storage.py
+++ b/app/ingestion/storage.py
@@ -6,15 +6,98 @@ embedding while centralizing persistence logic here.
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime
-from typing import Iterable, Optional
+from typing import Any, Callable, Iterable, Optional, Sequence
 from uuid import UUID, uuid4
 
 import psycopg
 from psycopg import sql
 from psycopg.types.json import Jsonb
 
-from .models import Job, JobStatus, Source, SourceType
+from .models import ChunkMetadata, DocumentVersion, Job, JobStatus, Source, SourceType
+
+
+def _encode_credentials(
+    credentials: Any | None,
+    *,
+    encrypt: Callable[[bytes], bytes] | None = None,
+) -> bytes | None:
+    """Serialize credentials to bytes with optional encryption."""
+
+    if credentials is None:
+        return None
+    if isinstance(credentials, bytes):
+        raw = credentials
+    elif isinstance(credentials, memoryview):
+        raw = bytes(credentials)
+    elif isinstance(credentials, str):
+        raw = credentials.encode("utf-8")
+    else:
+        raw = json.dumps(credentials).encode("utf-8")
+    return encrypt(raw) if encrypt else raw
+
+
+def _decode_credentials(
+    data: Any | None,
+    *,
+    decrypt: Callable[[bytes], bytes] | None = None,
+) -> Any | None:
+    """Decode credential payloads using optional decryption and JSON parsing."""
+
+    if data is None:
+        return None
+    if isinstance(data, memoryview):
+        payload = bytes(data)
+    elif isinstance(data, (bytes, bytearray)):
+        payload = bytes(data)
+    else:
+        # Already decoded (e.g., plain text from legacy rows)
+        payload = str(data).encode("utf-8")
+    if decrypt:
+        payload = decrypt(payload)
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except Exception:
+        try:
+            return payload.decode("utf-8")
+        except Exception:
+            return payload
+
+
+def _jsonb_or_none(value: Any | None) -> Jsonb | None:
+    if value is None or isinstance(value, Jsonb):
+        return value
+    return Jsonb(value)
+
+
+def _as_bytes(value: Any | None) -> bytes | None:
+    if value is None:
+        return None
+    if isinstance(value, memoryview):
+        return bytes(value)
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return value
+
+
+def _normalize_sync_state(value: Any | None) -> Any | None:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, memoryview):
+        payload = bytes(value)
+    elif isinstance(value, (bytes, bytearray)):
+        payload = bytes(value)
+    else:
+        payload = str(value).encode("utf-8")
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except Exception:
+        return payload
 
 
 def get_or_create_source(
@@ -25,8 +108,13 @@ def get_or_create_source(
     url: str | None = None,
     label: str | None = None,
     location: str | None = None,
-    active: bool = True,
+    active: bool | None = None,
     params: dict | None = None,
+    connector_type: str | None = None,
+    credentials: Any | None = None,
+    sync_state: dict | None = None,
+    version: int | None = None,
+    encrypt_credentials: Callable[[bytes], bytes] | None = None,
 ) -> UUID:
     """Fetch an existing source or create a new record.
 
@@ -36,6 +124,24 @@ def get_or_create_source(
 
     with conn.transaction():
         with conn.cursor() as cur:
+            update_kwargs: dict[str, Any] = {}
+            if label is not None:
+                update_kwargs["label"] = label
+            if location is not None:
+                update_kwargs["location"] = location
+            if active is not None:
+                update_kwargs["active"] = active
+            if params is not None:
+                update_kwargs["params"] = params
+            if connector_type is not None:
+                update_kwargs["connector_type"] = connector_type
+            if credentials is not None:
+                update_kwargs["credentials"] = credentials
+            if sync_state is not None:
+                update_kwargs["sync_state"] = sync_state
+            if version is not None:
+                update_kwargs["version"] = version
+
             if path is not None:
                 cur.execute(
                     "SELECT id FROM sources WHERE path = %s AND deleted_at IS NULL",
@@ -43,7 +149,15 @@ def get_or_create_source(
                 )
                 row = cur.fetchone()
                 if row:
-                    return row[0]
+                    source_id = row[0]
+                    if update_kwargs:
+                        update_source(
+                            conn,
+                            source_id,
+                            encrypt_credentials=encrypt_credentials,
+                            **update_kwargs,
+                        )
+                    return source_id
 
             if url is not None:
                 cur.execute(
@@ -52,13 +166,35 @@ def get_or_create_source(
                 )
                 row = cur.fetchone()
                 if row:
-                    return row[0]
+                    source_id = row[0]
+                    if update_kwargs:
+                        update_source(
+                            conn,
+                            source_id,
+                            encrypt_credentials=encrypt_credentials,
+                            **update_kwargs,
+                        )
+                    return source_id
 
             source_id = uuid4()
             cur.execute(
                 """
-                INSERT INTO sources (id, type, path, url, label, location, active, params, created_at)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, now())
+                INSERT INTO sources (
+                    id,
+                    type,
+                    path,
+                    url,
+                    label,
+                    location,
+                    active,
+                    params,
+                    connector_type,
+                    credentials,
+                    sync_state,
+                    version,
+                    created_at
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, now())
                 """,
                 (
                     source_id,
@@ -67,8 +203,12 @@ def get_or_create_source(
                     url,
                     label,
                     location,
-                    active,
+                    active if active is not None else True,
                     Jsonb(params) if params is not None else None,
+                    connector_type,
+                    _encode_credentials(credentials, encrypt=encrypt_credentials),
+                    _jsonb_or_none(sync_state),
+                    version or 1,
                 ),
             )
             return source_id
@@ -81,6 +221,7 @@ def list_sources(
     type: SourceType | None = None,
     limit: int | None = None,
     offset: int = 0,
+    decrypt_credentials: Callable[[bytes], bytes] | None = None,
 ) -> Iterable[Source]:
     """Return sources ordered by creation date with optional filters."""
 
@@ -94,7 +235,7 @@ def list_sources(
         params.append(type.value if isinstance(type, SourceType) else type)
 
     query = (
-        "SELECT id, type, label, location, path, url, active, params, created_at "
+        "SELECT id, type, label, location, path, url, active, params, connector_type, credentials, sync_state, version, created_at "
         "FROM sources WHERE " + " AND ".join(conditions) + " ORDER BY created_at DESC"
     )
     if limit is not None:
@@ -118,7 +259,11 @@ def list_sources(
             url=row[5],
             active=row[6],
             params=row[7],
-            created_at=row[8],
+            connector_type=row[8],
+            credentials=_decode_credentials(row[9], decrypt=decrypt_credentials),
+            sync_state=_normalize_sync_state(row[10]),
+            version=row[11] or 1,
+            created_at=row[12],
         )
 
 
@@ -261,6 +406,11 @@ def update_source(
     location: str | None = None,
     active: bool | None = None,
     params: dict | None = None,
+    connector_type: str | None = None,
+    credentials: Any | None = None,
+    sync_state: dict | None = None,
+    version: int | None = None,
+    encrypt_credentials: Callable[[bytes], bytes] | None = None,
 ) -> None:
     """Update fields for a source (partial update)."""
 
@@ -284,6 +434,18 @@ def update_source(
     if params is not None:
         fields.append(sql.SQL("params = %s"))
         values.append(Jsonb(params))
+    if connector_type is not None:
+        fields.append(sql.SQL("connector_type = %s"))
+        values.append(connector_type)
+    if credentials is not None:
+        fields.append(sql.SQL("credentials = %s"))
+        values.append(_encode_credentials(credentials, encrypt=encrypt_credentials))
+    if sync_state is not None:
+        fields.append(sql.SQL("sync_state = %s"))
+        values.append(_jsonb_or_none(sync_state))
+    if version is not None:
+        fields.append(sql.SQL("version = %s"))
+        values.append(version)
 
     if not fields:
         return
@@ -306,5 +468,294 @@ def soft_delete_source(conn: psycopg.Connection, source_id: UUID) -> None:
             cur.execute(
                 "UPDATE sources SET active = FALSE, deleted_at = now(), updated_at = now() WHERE id = %s",
                 (source_id,),
+            )
+
+
+def upsert_document(
+    conn: psycopg.Connection,
+    *,
+    path: str,
+    bytes_len: int | None = None,
+    page_count: int | None = None,
+    source_id: UUID | None = None,
+    connector_type: str | None = None,
+    credentials: Any | None = None,
+    sync_state: dict | None = None,
+    encrypt_credentials: Callable[[bytes], bytes] | None = None,
+    decrypt_credentials: Callable[[bytes], bytes] | None = None,
+) -> DocumentVersion:
+    """Insert or update a document row and persist a version snapshot."""
+
+    encoded_credentials = _encode_credentials(credentials, encrypt=encrypt_credentials)
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, version, source_id, connector_type, credentials, sync_state, bytes, page_count
+                FROM documents
+                WHERE path = %s
+                FOR UPDATE
+                """,
+                (path,),
+            )
+            row = cur.fetchone()
+
+            if row:
+                (
+                    doc_id,
+                    current_version,
+                    existing_source_id,
+                    existing_connector_type,
+                    existing_credentials,
+                    existing_sync_state,
+                    existing_bytes,
+                    existing_page_count,
+                ) = row
+                new_version = (current_version or 0) + 1
+                next_source_id = source_id if source_id is not None else existing_source_id
+                next_connector_type = (
+                    connector_type if connector_type is not None else existing_connector_type
+                )
+                next_credentials = (
+                    encoded_credentials if credentials is not None else _as_bytes(existing_credentials)
+                )
+                next_sync_state = sync_state if sync_state is not None else existing_sync_state
+                next_bytes = bytes_len if bytes_len is not None else existing_bytes
+                next_page_count = page_count if page_count is not None else existing_page_count
+
+                if next_connector_type is None and next_source_id is not None:
+                    cur.execute(
+                        "SELECT connector_type FROM sources WHERE id = %s",
+                        (next_source_id,),
+                    )
+                    src_row = cur.fetchone()
+                    if src_row and src_row[0]:
+                        next_connector_type = src_row[0]
+
+                cur.execute(
+                    """
+                    UPDATE documents
+                    SET bytes = %s,
+                        page_count = %s,
+                        source_id = %s,
+                        connector_type = %s,
+                        credentials = %s,
+                        sync_state = %s,
+                        version = %s
+                    WHERE id = %s
+                    """,
+                    (
+                        next_bytes,
+                        next_page_count,
+                        next_source_id,
+                        next_connector_type,
+                        next_credentials,
+                        _jsonb_or_none(next_sync_state),
+                        new_version,
+                        doc_id,
+                    ),
+                )
+            else:
+                doc_id = uuid4()
+                new_version = 1
+                next_source_id = source_id
+                next_connector_type = connector_type
+                next_credentials = encoded_credentials
+                next_sync_state = sync_state
+                next_bytes = bytes_len
+                next_page_count = page_count
+
+                if next_connector_type is None and next_source_id is not None:
+                    cur.execute(
+                        "SELECT connector_type FROM sources WHERE id = %s",
+                        (next_source_id,),
+                    )
+                    src_row = cur.fetchone()
+                    if src_row and src_row[0]:
+                        next_connector_type = src_row[0]
+
+                cur.execute(
+                    """
+                    INSERT INTO documents (
+                        id,
+                        path,
+                        bytes,
+                        page_count,
+                        source_id,
+                        connector_type,
+                        credentials,
+                        sync_state,
+                        version,
+                        created_at
+                    )
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, now())
+                    """,
+                    (
+                        doc_id,
+                        path,
+                        next_bytes,
+                        next_page_count,
+                        next_source_id,
+                        next_connector_type,
+                        next_credentials,
+                        _jsonb_or_none(next_sync_state),
+                        new_version,
+                    ),
+                )
+
+            cur.execute(
+                """
+                INSERT INTO document_versions (
+                    document_id,
+                    source_id,
+                    version,
+                    bytes,
+                    page_count,
+                    connector_type,
+                    credentials,
+                    sync_state
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (document_id, version) DO UPDATE
+                SET bytes = EXCLUDED.bytes,
+                    page_count = EXCLUDED.page_count,
+                    connector_type = EXCLUDED.connector_type,
+                    credentials = EXCLUDED.credentials,
+                    sync_state = EXCLUDED.sync_state
+                RETURNING created_at
+                """,
+                (
+                    doc_id,
+                    next_source_id,
+                    new_version,
+                    next_bytes,
+                    next_page_count,
+                    next_connector_type,
+                    next_credentials,
+                    _jsonb_or_none(next_sync_state),
+                ),
+            )
+            created_at = cur.fetchone()[0]
+
+    return DocumentVersion(
+        document_id=doc_id,
+        source_id=next_source_id,
+        version=new_version,
+        bytes=next_bytes,
+        page_count=next_page_count,
+        connector_type=next_connector_type,
+        credentials=_decode_credentials(next_credentials, decrypt=decrypt_credentials),
+        sync_state=_normalize_sync_state(next_sync_state),
+        created_at=created_at,
+    )
+
+
+def insert_chunks(
+    conn: psycopg.Connection,
+    *,
+    document_id: UUID,
+    chunks: Sequence[str],
+    embeddings: Sequence[Sequence[float]],
+    metadatas: Sequence[ChunkMetadata],
+) -> None:
+    """Insert chunk rows ensuring metadata is persisted as JSONB."""
+
+    with conn.transaction():
+        with conn.cursor() as cur:
+            for index, (content, embedding, metadata) in enumerate(
+                zip(chunks, embeddings, metadatas)
+            ):
+                cur.execute(
+                    """
+                    INSERT INTO chunks (doc_id, chunk_index, content, token_est, metadata, embedding)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (doc_id, chunk_index) DO UPDATE
+                    SET content = EXCLUDED.content,
+                        token_est = EXCLUDED.token_est,
+                        metadata = EXCLUDED.metadata,
+                        embedding = EXCLUDED.embedding
+                    """,
+                    (
+                        document_id,
+                        index,
+                        content,
+                        int(len(content) / 4) if content else 0,
+                        _jsonb_or_none(metadata.to_json()),
+                        embedding,
+                    ),
+                )
+
+
+def update_source_sync_state(
+    conn: psycopg.Connection,
+    source_id: UUID,
+    *,
+    sync_state: dict | None,
+    version: int | None = None,
+) -> None:
+    """Update the stored sync cursor/state for a connector source."""
+
+    fields: list[sql.SQL] = [sql.SQL("sync_state = %s")]
+    values: list[Any] = [_jsonb_or_none(sync_state)]
+    if version is not None:
+        fields.append(sql.SQL("version = %s"))
+        values.append(version)
+
+    query = sql.SQL("UPDATE sources SET {fields}, updated_at = now() WHERE id = %s").format(
+        fields=sql.SQL(", ").join(fields)
+    )
+    values.append(source_id)
+
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.execute(query, values)
+
+
+def get_latest_versions_for_connector(
+    conn: psycopg.Connection,
+    *,
+    connector_type: str,
+    source_id: UUID | None = None,
+    decrypt_credentials: Callable[[bytes], bytes] | None = None,
+) -> Iterable[DocumentVersion]:
+    """Yield the latest document version entries for a given connector."""
+
+    query = """
+        SELECT dv.document_id,
+               dv.source_id,
+               dv.version,
+               dv.bytes,
+               dv.page_count,
+               dv.connector_type,
+               dv.credentials,
+               dv.sync_state,
+               dv.created_at
+        FROM document_versions dv
+        JOIN (
+            SELECT document_id, MAX(version) AS max_version
+            FROM document_versions
+            GROUP BY document_id
+        ) latest ON latest.document_id = dv.document_id AND latest.max_version = dv.version
+        JOIN documents d ON d.id = dv.document_id
+        WHERE d.connector_type = %s
+    """
+    params: list[Any] = [connector_type]
+    if source_id is not None:
+        query += " AND dv.source_id = %s"
+        params.append(source_id)
+
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        for row in cur.fetchall():
+            yield DocumentVersion(
+                document_id=row[0],
+                source_id=row[1],
+                version=row[2],
+                bytes=row[3],
+                page_count=row[4],
+                connector_type=row[5],
+                credentials=_decode_credentials(row[6], decrypt=decrypt_credentials),
+                sync_state=_normalize_sync_state(row[7]),
+                created_at=row[8],
             )
 

--- a/app/routers/admin_ingest_api.py
+++ b/app/routers/admin_ingest_api.py
@@ -190,6 +190,10 @@ def create_source(
             location=req.location,
             active=req.active,
             params=req.params,
+            connector_type=req.connector_type,
+            credentials=req.credentials,
+            sync_state=req.sync_state,
+            version=req.version,
         )
         return _fetch_source(conn, source_id)
 
@@ -210,6 +214,10 @@ def update_source(
             location=req.location,
             active=req.active,
             params=req.params,
+            connector_type=req.connector_type,
+            credentials=req.credentials,
+            sync_state=req.sync_state,
+            version=req.version,
         )
         return _fetch_source(conn, source_id)
 

--- a/migrations/008_ingestion_connectors.sql
+++ b/migrations/008_ingestion_connectors.sql
@@ -1,0 +1,30 @@
+-- Extend ingestion entities with connector metadata and document version history
+ALTER TABLE sources
+    ADD COLUMN IF NOT EXISTS connector_type TEXT,
+    ADD COLUMN IF NOT EXISTS credentials BYTEA,
+    ADD COLUMN IF NOT EXISTS sync_state JSONB,
+    ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE documents
+    ADD COLUMN IF NOT EXISTS source_id UUID REFERENCES sources(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS connector_type TEXT,
+    ADD COLUMN IF NOT EXISTS credentials BYTEA,
+    ADD COLUMN IF NOT EXISTS sync_state JSONB,
+    ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE chunks
+    ADD COLUMN IF NOT EXISTS metadata JSONB;
+
+CREATE TABLE IF NOT EXISTS document_versions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    source_id UUID REFERENCES sources(id) ON DELETE SET NULL,
+    version INTEGER NOT NULL,
+    bytes BIGINT,
+    page_count INT,
+    connector_type TEXT,
+    credentials BYTEA,
+    sync_state JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (document_id, version)
+);

--- a/schema.sql
+++ b/schema.sql
@@ -1,16 +1,84 @@
--- Habilita o tipo vector (imagem já vem com a extensão)
+-- Base schema for the knowledge kit database.
+--
+-- The schema is intentionally idempotent so that ``ensure_schema`` can run the
+-- file on every startup. Tables are defined with ``IF NOT EXISTS`` clauses and
+-- column defaults mirror the latest migrations, ensuring that fresh installs do
+-- not rely on incremental migrations to get the correct shape.
+
+-- Required extensions -------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS pgcrypto; -- for gen_random_uuid
 CREATE EXTENSION IF NOT EXISTS vector;
 
--- Tabela de documentos
+-- Ingestion sources ---------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  type TEXT NOT NULL,
+  label TEXT,
+  location TEXT,
+  path TEXT,
+  url TEXT,
+  params JSONB,
+  connector_type TEXT,
+  credentials BYTEA,
+  sync_state JSONB,
+  version INTEGER NOT NULL DEFAULT 1,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ,
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_sources_active ON sources (active);
+CREATE INDEX IF NOT EXISTS idx_sources_path_active ON sources (path) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_sources_url_active ON sources (url) WHERE deleted_at IS NULL;
+
+-- Ingestion jobs ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ingestion_jobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_id UUID NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  params JSONB,
+  status TEXT NOT NULL,
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  log_path TEXT,
+  error TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_jobs_status ON ingestion_jobs (status);
+CREATE INDEX IF NOT EXISTS idx_ingestion_jobs_source_id ON ingestion_jobs (source_id);
+
+-- Documents -----------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS documents (
   id UUID PRIMARY KEY,
+  source_id UUID REFERENCES sources(id) ON DELETE SET NULL,
   path TEXT NOT NULL UNIQUE,
   bytes BIGINT,
   page_count INT,
+  connector_type TEXT,
+  credentials BYTEA,
+  sync_state JSONB,
+  version INTEGER NOT NULL DEFAULT 1,
   created_at TIMESTAMPTZ DEFAULT now()
 );
 
--- Tabela de chunks
+-- Document history ----------------------------------------------------------
+CREATE TABLE IF NOT EXISTS document_versions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  source_id UUID REFERENCES sources(id) ON DELETE SET NULL,
+  version INTEGER NOT NULL,
+  bytes BIGINT,
+  page_count INT,
+  connector_type TEXT,
+  credentials BYTEA,
+  sync_state JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (document_id, version)
+);
+
+-- Chunks --------------------------------------------------------------------
 -- Dimensão 384 para o modelo 'sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2'
 CREATE TABLE IF NOT EXISTS chunks (
   id BIGSERIAL PRIMARY KEY,
@@ -23,9 +91,83 @@ CREATE TABLE IF NOT EXISTS chunks (
   UNIQUE (doc_id, chunk_index)
 );
 
--- Índices úteis
 CREATE INDEX IF NOT EXISTS idx_chunks_doc ON chunks (doc_id, chunk_index);
--- Índice vetorial (crie após a ingestão de um volume inicial)
--- Para L2:
 -- CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON chunks USING ivfflat (embedding vector_l2_ops) WITH (lists = 100);
--- E rode ANALYZE depois de popular a tabela.
+
+-- User feedback -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS feedbacks (
+  id UUID PRIMARY KEY,
+  helpful BOOLEAN NOT NULL,
+  question TEXT,
+  answer TEXT,
+  session_id TEXT,
+  sources JSONB,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedbacks_created_at ON feedbacks (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_feedbacks_helpful ON feedbacks (helpful);
+
+-- Agent registry ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS agents (
+  id BIGSERIAL PRIMARY KEY,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  description TEXT,
+  provider TEXT NOT NULL,
+  model TEXT NOT NULL,
+  persona JSONB NOT NULL DEFAULT '{}'::jsonb,
+  prompt_template TEXT,
+  response_params JSONB NOT NULL DEFAULT '{}'::jsonb,
+  deployment_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION set_agents_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS agents_updated_at ON agents;
+CREATE TRIGGER agents_updated_at
+BEFORE UPDATE ON agents
+FOR EACH ROW
+EXECUTE PROCEDURE set_agents_updated_at();
+
+CREATE TABLE IF NOT EXISTS agent_versions (
+  id BIGSERIAL PRIMARY KEY,
+  agent_id BIGINT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  version INTEGER NOT NULL,
+  label TEXT,
+  created_by TEXT,
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  prompt_template TEXT,
+  persona JSONB NOT NULL DEFAULT '{}'::jsonb,
+  response_params JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(agent_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_versions_agent_id ON agent_versions(agent_id);
+
+CREATE TABLE IF NOT EXISTS agent_tests (
+  id BIGSERIAL PRIMARY KEY,
+  agent_version_id BIGINT REFERENCES agent_versions(id) ON DELETE CASCADE,
+  agent_id BIGINT REFERENCES agents(id) ON DELETE CASCADE,
+  input_prompt TEXT NOT NULL,
+  expected_behavior TEXT,
+  response JSONB,
+  metrics JSONB,
+  status TEXT NOT NULL DEFAULT 'pending',
+  channel TEXT,
+  ran_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_tests_agent_id ON agent_tests(agent_id);
+CREATE INDEX IF NOT EXISTS idx_agent_tests_agent_version_id ON agent_tests(agent_version_id);


### PR DESCRIPTION
## Summary
- add connector metadata columns to sources/documents and introduce the document_versions history table
- extend ingestion models and services to expose chunk metadata and document version information
- enhance storage helpers to serialize credentials, upsert document versions, update sync cursors, and reuse metadata when inserting chunks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcfcf705288323b0c072063acda862