### PR TITLE
Add SQL and REST connectors with ingest_source orchestration

### DIFF
--- a/app/ingestion/__init__.py
+++ b/app/ingestion/__init__.py
@@ -11,12 +11,12 @@ from .service import (
     read_md_text,
     read_pdf_text,
     read_url_text,
-    chunk_text,
     upsert_document,
     insert_chunks,
     ingest_local,
     ingest_url,
     ingest_urls,
+    ingest_source,
     reindex_source,
     rerun_job,
     cancel_job,
@@ -26,6 +26,7 @@ from .service import (
     TextEmbedding,
     EMBEDDING_MODEL,
 )
+from .chunking import chunk_text
 
 __all__ = [
     "Chunk",
@@ -43,6 +44,7 @@ __all__ = [
     "ingest_local",
     "ingest_url",
     "ingest_urls",
+    "ingest_source",
     "reindex_source",
     "rerun_job",
     "cancel_job",

--- a/app/ingestion/chunking.py
+++ b/app/ingestion/chunking.py
@@ -1,0 +1,69 @@
+"""Utilities for transforming raw text into embedding-ready chunks."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .parsers import Chunk
+
+
+def chunk_text(
+    text: str,
+    *,
+    source_path: str,
+    mime_type: str,
+    page_number: int | None = None,
+    sheet_name: str | None = None,
+    row_number: int | None = None,
+    extra_metadata: Dict[str, object] | None = None,
+    max_chars: int = 1200,
+    overlap: int = 200,
+) -> List[Chunk]:
+    """Split text into :class:`Chunk` objects with optional metadata."""
+
+    if not text:
+        return []
+    text = text.replace("\r", "")
+    parts = text.split("\n\n")
+    text_chunks: List[str] = []
+    buf = ""
+    for part in parts:
+        if len(buf) + len(part) + 2 <= max_chars:
+            buf += (("\n\n" if buf else "") + part)
+        else:
+            if buf:
+                text_chunks.append(buf.strip())
+            buf = part
+            while len(buf) > max_chars:
+                text_chunks.append(buf[:max_chars].strip())
+                buf = buf[max_chars - overlap:]
+    if buf:
+        text_chunks.append(buf.strip())
+
+    normalized: List[str] = []
+    for i, ch in enumerate(text_chunks):
+        if i == 0:
+            normalized.append(ch)
+        else:
+            prev = normalized[-1]
+            tail = prev[-overlap:] if len(prev) > overlap else prev
+            merged = (tail + "\n\n" + ch).strip() if tail else ch
+            normalized.append(merged if len(merged) <= max_chars + overlap else ch)
+
+    extra = dict(extra_metadata or {})
+    return [
+        Chunk(
+            content=chunk_text,
+            source_path=source_path,
+            mime_type=mime_type,
+            page_number=page_number,
+            sheet_name=sheet_name,
+            row_number=row_number,
+            extra=extra,
+        )
+        for chunk_text in normalized
+    ]
+
+
+__all__ = ["chunk_text"]
+

--- a/app/ingestion/connectors/__init__.py
+++ b/app/ingestion/connectors/__init__.py
@@ -1,0 +1,24 @@
+"""Connector abstractions for external data sources."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from ..parsers import Chunk
+
+
+@dataclass(slots=True)
+class ConnectorRecord:
+    """Represents a document worth of chunks produced by a connector."""
+
+    document_path: str
+    chunks: List[Chunk]
+    bytes_len: int
+    page_count: int = 1
+    document_sync_state: Dict[str, object] | None = None
+    extra_info: Dict[str, object] = field(default_factory=dict)
+
+
+__all__ = ["ConnectorRecord"]
+

--- a/app/ingestion/connectors/rest.py
+++ b/app/ingestion/connectors/rest.py
@@ -1,0 +1,254 @@
+"""REST connector that fetches JSON resources and emits text chunks."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from decimal import Decimal
+from threading import Event
+from typing import Any, Dict, Iterable, List
+from urllib.parse import urljoin
+
+import requests
+
+from ..chunking import chunk_text
+from ..models import ApiSourceParams, Source
+from . import ConnectorRecord
+
+
+class RestConnector:
+    """Fetch paginated REST endpoints and emit chunks for each record."""
+
+    def __init__(
+        self,
+        source: Source,
+        *,
+        session: requests.Session | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.source = source
+        self.logger = logger or logging.getLogger(__name__)
+        self.session = session or requests.Session()
+        params: ApiSourceParams | Dict[str, Any] = source.params or {}
+        endpoint = params.get("endpoint")
+        if not endpoint and not source.url:
+            raise ValueError("REST connector requires params.endpoint or source.url")
+        base_url = params.get("base_url") or (str(source.url) if source.url else "")
+        if endpoint and endpoint.startswith("http"):
+            self._endpoint_url = endpoint
+        elif endpoint:
+            if not base_url:
+                raise ValueError("REST connector requires params.base_url when endpoint is relative")
+            self._endpoint_url = urljoin(base_url.rstrip("/") + "/", endpoint.lstrip("/"))
+        else:
+            self._endpoint_url = base_url
+
+        self._method = (params.get("method") or "GET").upper()
+        self._headers = self._prepare_headers(params.get("headers") or {})
+        self._query_params = dict(params.get("query_params") or {})
+        self._body = dict(params.get("body") or {})
+        self._pagination = dict(params.get("pagination") or {})
+        self._records_path = params.get("records_path") or "data"
+        self._id_field = params.get("id_field") or "id"
+        self._text_fields = params.get("text_fields") or ["content"]
+        self._timestamp_field = params.get("timestamp_field")
+        self._mime_type = params.get("mime_type") or "application/json"
+        self._document_template = (
+            params.get("document_path_template")
+            or "{endpoint}/{id}"
+        )
+
+        base_state = dict(source.sync_state or {})
+        self.next_sync_state: Dict[str, Any] = dict(base_state)
+        self.job_metadata: Dict[str, Any] = {
+            "pages": 0,
+            "records": 0,
+            "chunks": 0,
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _prepare_headers(self, headers: Dict[str, str]) -> Dict[str, str]:
+        prepared = dict(headers)
+        credentials = self.source.credentials or {}
+        if isinstance(credentials, dict):
+            for key, value in list(prepared.items()):
+                if isinstance(value, str):
+                    try:
+                        prepared[key] = value.format(**credentials)
+                    except Exception:
+                        prepared[key] = value
+        elif isinstance(credentials, str):
+            for key, value in list(prepared.items()):
+                if isinstance(value, str):
+                    prepared[key] = value.format(token=credentials)
+        return prepared
+
+    @staticmethod
+    def _json_safe(value: Any) -> Any:
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+        if isinstance(value, Decimal):
+            return float(value)
+        return str(value)
+
+    @staticmethod
+    def _lookup(payload: Any, path: str | None) -> Any:
+        if not path:
+            return payload
+        current = payload
+        for part in path.split('.'):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            elif isinstance(current, list):
+                try:
+                    index = int(part)
+                except ValueError:
+                    return None
+                if 0 <= index < len(current):
+                    current = current[index]
+                else:
+                    return None
+            else:
+                return None
+        return current
+
+    def _prepare_request(self, cursor: Any, page: int | None) -> Dict[str, Any]:
+        params = dict(self._query_params)
+        pagination_type = self._pagination.get("type", "cursor")
+        if pagination_type == "cursor" and cursor is not None:
+            params[self._pagination.get("cursor_param", "cursor")] = cursor
+        elif pagination_type == "page" and page is not None:
+            params[self._pagination.get("page_param", "page")] = page
+            if self._pagination.get("page_size_param") and self._pagination.get("page_size"):
+                params.setdefault(
+                    self._pagination["page_size_param"],
+                    self._pagination["page_size"],
+                )
+
+        request_kwargs: Dict[str, Any] = {"headers": self._headers, "timeout": 30}
+        if self._method in {"GET", "DELETE"}:
+            request_kwargs["params"] = params
+        else:
+            request_kwargs["params"] = params
+            request_kwargs["json"] = self._body
+        return request_kwargs
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def stream(self, cancel_event: Event | None = None) -> Iterable[ConnectorRecord]:
+        """Yield :class:`ConnectorRecord` entries for each REST resource."""
+
+        pagination_type = self._pagination.get("type", "cursor")
+        cursor = self.next_sync_state.get("cursor")
+        page = self.next_sync_state.get("page", self._pagination.get("start_page", 1))
+
+        while True:
+            if cancel_event and cancel_event.is_set():
+                break
+
+            request_kwargs = self._prepare_request(cursor, page if pagination_type == "page" else None)
+            response = self.session.request(self._method, self._endpoint_url, **request_kwargs)
+            response.raise_for_status()
+            payload = response.json()
+            self.job_metadata["pages"] += 1
+
+            records = self._lookup(payload, self._records_path)
+            if records is None:
+                records = []
+            if not isinstance(records, list):
+                raise ValueError("REST connector expects the records_path to resolve to a list")
+
+            for record in records:
+                if cancel_event and cancel_event.is_set():
+                    break
+
+                text_parts: List[str] = []
+                for field in self._text_fields:
+                    value = self._lookup(record, field)
+                    if value is not None:
+                        text_parts.append(str(value))
+
+                text_body = "\n\n".join(part for part in text_parts if part).strip()
+                if not text_body:
+                    continue
+
+                record_id = self._lookup(record, self._id_field)
+                if record_id is None:
+                    raise ValueError("REST connector requires id_field to be present in records")
+
+                timestamp_value = None
+                if self._timestamp_field:
+                    timestamp_value = self._lookup(record, self._timestamp_field)
+
+                document_path = self._document_template.format(
+                    endpoint=self._endpoint_url.rstrip("/").split("//")[-1],
+                    id=record_id,
+                )
+
+                extra_metadata: Dict[str, Any] = {
+                    "connector": "rest",
+                    "endpoint": self._endpoint_url,
+                    "record_id": self._json_safe(record_id),
+                }
+                if timestamp_value is not None:
+                    extra_metadata["timestamp"] = self._json_safe(timestamp_value)
+
+                chunks = chunk_text(
+                    text_body,
+                    source_path=document_path,
+                    mime_type=self._mime_type,
+                    page_number=1,
+                    extra_metadata=extra_metadata,
+                )
+
+                if not chunks:
+                    continue
+
+                self.job_metadata["records"] += 1
+                self.job_metadata["chunks"] += len(chunks)
+
+                document_state = {
+                    "record_id": self._json_safe(record_id),
+                }
+                if timestamp_value is not None:
+                    document_state["timestamp"] = self._json_safe(timestamp_value)
+
+                yield ConnectorRecord(
+                    document_path=document_path,
+                    chunks=chunks,
+                    bytes_len=len(text_body.encode("utf-8")),
+                    page_count=1,
+                    document_sync_state=document_state,
+                    extra_info={
+                        "endpoint": self._endpoint_url,
+                        "record_id": self._json_safe(record_id),
+                    },
+                )
+
+            # Pagination cursor update
+            if pagination_type == "cursor":
+                next_cursor = self._lookup(payload, self._pagination.get("next_cursor_path", "next"))
+                if not next_cursor or next_cursor == cursor:
+                    self.next_sync_state["cursor"] = self._json_safe(next_cursor)
+                    break
+                cursor = next_cursor
+                self.next_sync_state["cursor"] = self._json_safe(cursor)
+            else:
+                page = (page or 0) + 1
+                self.next_sync_state["page"] = page
+                expected_page_size = self._pagination.get("page_size")
+                if expected_page_size and len(records) < int(expected_page_size):
+                    break
+                if not records:
+                    break
+
+
+__all__ = ["RestConnector"]
+

--- a/app/ingestion/connectors/sql.py
+++ b/app/ingestion/connectors/sql.py
@@ -1,0 +1,201 @@
+"""Database connector that streams rows as text chunks."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from decimal import Decimal
+from threading import Event
+from typing import Any, Dict, Iterable, List
+
+import psycopg
+from psycopg import conninfo as psycopg_conninfo
+from psycopg.rows import dict_row
+
+from ..chunking import chunk_text
+from ..models import DatabaseQueryConfig, DatabaseSourceParams, Source
+from . import ConnectorRecord
+
+
+class SqlConnector:
+    """Execute configured SQL queries and emit chunked rows."""
+
+    def __init__(self, source: Source, *, logger: logging.Logger | None = None):
+        self.source = source
+        self.logger = logger or logging.getLogger(__name__)
+        params: DatabaseSourceParams | Dict[str, Any] = source.params or {}
+        queries = list(params.get("queries") or [])
+        if not queries:
+            raise ValueError("database connector requires params.queries")
+        self._queries: List[DatabaseQueryConfig] = queries
+        self._conninfo = self._resolve_conninfo(params, source.credentials)
+        base_state = dict(source.sync_state or {})
+        queries_state = dict(base_state.get("queries") or {})
+        self.next_sync_state: Dict[str, Any] = {**base_state, "queries": dict(queries_state)}
+        self.job_metadata: Dict[str, Any] = {
+            "queries": len(self._queries),
+            "rows": 0,
+            "chunks": 0,
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_conninfo(params: DatabaseSourceParams | Dict[str, Any], credentials: Any) -> str:
+        if isinstance(params, dict) and params.get("dsn"):
+            return str(params["dsn"])
+
+        options: Dict[str, Any] = {}
+        if isinstance(params, dict):
+            if params.get("host"):
+                options["host"] = params["host"]
+            if params.get("port"):
+                options["port"] = params["port"]
+            if params.get("database"):
+                options["dbname"] = params["database"]
+            if params.get("user"):
+                options["user"] = params["user"]
+
+        if isinstance(credentials, dict):
+            if credentials.get("username") and not options.get("user"):
+                options["user"] = credentials.get("username")
+            if credentials.get("user") and not options.get("user"):
+                options["user"] = credentials.get("user")
+            if credentials.get("password"):
+                options["password"] = credentials.get("password")
+        elif isinstance(credentials, str) and credentials:
+            options.setdefault("password", credentials)
+
+        clean_opts = {k: v for k, v in options.items() if v is not None}
+        if not clean_opts:
+            raise ValueError("database connector requires connection parameters or credentials")
+        return psycopg_conninfo.make_conninfo(**clean_opts)
+
+    @staticmethod
+    def _json_safe(value: Any) -> Any:
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        if isinstance(value, (datetime, date)):
+            return value.isoformat()
+        if isinstance(value, Decimal):
+            return float(value)
+        return str(value)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def stream(self, cancel_event: Event | None = None) -> Iterable[ConnectorRecord]:
+        """Yield :class:`ConnectorRecord` entries for each database row."""
+
+        base_state = dict(self.source.sync_state or {})
+        existing_queries = dict(base_state.get("queries") or {})
+        next_queries: Dict[str, Any] = dict(existing_queries)
+
+        with psycopg.connect(self._conninfo, row_factory=dict_row) as conn:
+            for index, query_cfg in enumerate(self._queries):
+                if cancel_event and cancel_event.is_set():
+                    break
+
+                query_name = query_cfg.get("name") or query_cfg.get("table") or f"query_{index}"
+                sql = query_cfg.get("sql")
+                if not sql:
+                    raise ValueError(f"query '{query_name}' is missing required sql")
+
+                text_column = query_cfg.get("text_column")
+                id_column = query_cfg.get("id_column")
+                if not text_column or not id_column:
+                    raise ValueError(f"query '{query_name}' requires text_column and id_column")
+
+                cursor_column = query_cfg.get("cursor_column")
+                cursor_param = query_cfg.get("cursor_param", "cursor")
+                query_params = dict(query_cfg.get("params") or {})
+                existing_cursor_state = existing_queries.get(query_name) or {}
+                cursor_value = existing_cursor_state.get("cursor", query_cfg.get("initial_cursor"))
+                if cursor_column and cursor_value is not None:
+                    query_params.setdefault(cursor_param, cursor_value)
+
+                latest_cursor = None
+
+                with conn.cursor(row_factory=dict_row) as cur:
+                    cur.execute(sql, query_params or None)
+                    for row in cur:
+                        if cancel_event and cancel_event.is_set():
+                            break
+
+                        text_value = row.get(text_column)
+                        if text_value is None:
+                            continue
+
+                        record_id = row.get(id_column)
+                        document_template = query_cfg.get("document_path_template") or "{table}/{id}"
+                        document_path = document_template.format(
+                            table=query_cfg.get("table") or query_name,
+                            id=record_id,
+                            query=query_name,
+                        )
+
+                        extra_metadata: Dict[str, Any] = {
+                            "connector": "sql",
+                            "query": query_name,
+                            "table": query_cfg.get("table") or query_name,
+                            "row_id": self._json_safe(record_id),
+                        }
+
+                        for column in query_cfg.get("extra_metadata_fields") or []:
+                            if column in row:
+                                extra_metadata[column] = self._json_safe(row[column])
+
+                        if cursor_column and cursor_column in row:
+                            latest_cursor = row[cursor_column]
+                            extra_metadata[cursor_column] = self._json_safe(latest_cursor)
+
+                        text_str = str(text_value)
+                        chunks = chunk_text(
+                            text_str,
+                            source_path=document_path,
+                            mime_type=query_cfg.get("mime_type", "text/plain"),
+                            page_number=1,
+                            extra_metadata=extra_metadata,
+                        )
+
+                        if not chunks:
+                            continue
+
+                        self.job_metadata["rows"] += 1
+                        self.job_metadata["chunks"] += len(chunks)
+
+                        document_state: Dict[str, Any] | None = None
+                        if cursor_column and latest_cursor is not None:
+                            document_state = {
+                                "query": query_name,
+                                "cursor_column": cursor_column,
+                                "cursor": self._json_safe(latest_cursor),
+                                "row_id": self._json_safe(record_id),
+                            }
+
+                        yield ConnectorRecord(
+                            document_path=document_path,
+                            chunks=chunks,
+                            bytes_len=len(text_str.encode("utf-8")),
+                            page_count=1,
+                            document_sync_state=document_state,
+                            extra_info={
+                                "query": query_name,
+                                "row_id": self._json_safe(record_id),
+                            },
+                        )
+
+                if latest_cursor is not None:
+                    next_queries[query_name] = {
+                        "cursor": self._json_safe(latest_cursor),
+                        "cursor_column": cursor_column,
+                    }
+
+        self.next_sync_state = {**base_state, "queries": next_queries}
+
+
+__all__ = ["SqlConnector"]
+

--- a/app/ingestion/models.py
+++ b/app/ingestion/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Optional, TypeVar, TypedDict
 from uuid import UUID
 
 from pydantic import BaseModel, HttpUrl
@@ -21,6 +21,66 @@ class SourceType(str, Enum):
     LOCAL_DIR = "local_dir"
     URL = "url"
     URL_LIST = "url_list"
+    DATABASE = "database"
+    API = "api"
+
+
+class DatabaseQueryConfig(TypedDict, total=False):
+    """Configuration for a single SQL query executed by the database connector."""
+
+    name: str
+    sql: str
+    text_column: str
+    id_column: str
+    cursor_column: str
+    cursor_param: str
+    initial_cursor: str | int | float | None
+    mime_type: str
+    document_path_template: str
+    params: Dict[str, Any]
+    extra_metadata_fields: List[str]
+
+
+class DatabaseSourceParams(TypedDict, total=False):
+    """Expected ``sources.params`` payload for :class:`~SourceType.DATABASE`."""
+
+    dsn: str
+    driver: str
+    host: str
+    port: int
+    database: str
+    user: str
+    queries: List[DatabaseQueryConfig]
+
+
+class ApiPaginationConfig(TypedDict, total=False):
+    """Pagination behaviour for the REST connector."""
+
+    type: str  # "cursor" (default) or "page"
+    cursor_param: str
+    next_cursor_path: str
+    page_param: str
+    page_size_param: str
+    page_size: int
+    start_page: int
+
+
+class ApiSourceParams(TypedDict, total=False):
+    """Expected ``sources.params`` payload for :class:`~SourceType.API`."""
+
+    base_url: str
+    endpoint: str
+    method: str
+    headers: Dict[str, str]
+    query_params: Dict[str, Any]
+    body: Dict[str, Any]
+    pagination: ApiPaginationConfig
+    records_path: str
+    id_field: str
+    text_fields: List[str]
+    timestamp_field: str
+    mime_type: str
+    document_path_template: str
 
 
 class JobStatus(str, Enum):
@@ -73,7 +133,7 @@ class SourceCreate(BaseModel):
     label: str | None = None
     location: str | None = None
     active: bool = True
-    params: dict | None = None
+    params: DatabaseSourceParams | ApiSourceParams | Dict[str, Any] | None = None
     connector_type: str | None = None
     credentials: Any | None = None
     sync_state: dict | None = None
@@ -88,7 +148,7 @@ class SourceUpdate(BaseModel):
     label: str | None = None
     location: str | None = None
     active: bool | None = None
-    params: dict | None = None
+    params: DatabaseSourceParams | ApiSourceParams | Dict[str, Any] | None = None
     connector_type: str | None = None
     credentials: Any | None = None
     sync_state: dict | None = None
@@ -114,7 +174,7 @@ class Source(BaseModel):
     path: str | None = None
     url: HttpUrl | None = None
     active: bool = True
-    params: dict | None = None
+    params: DatabaseSourceParams | ApiSourceParams | Dict[str, Any] | None = None
     connector_type: str | None = None
     credentials: Any | None = None
     sync_state: dict | None = None

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -62,7 +62,7 @@ def test_ingest_local_and_url(tmp_path, monkeypatch):
 
     jobs: dict[uuid.UUID, service.Job] = {}
 
-    def create_job(conn, source_id, status=JobStatus.QUEUED):
+    def create_job(conn, source_id, status=JobStatus.QUEUED, params=None):
         jid = uuid4()
         jobs[jid] = service.Job(
             id=jid,
@@ -117,7 +117,7 @@ def test_ingest_local_error(tmp_path, monkeypatch):
 
     jobs: dict[uuid.UUID, service.Job] = {}
 
-    def create_job(conn, source_id, status=JobStatus.QUEUED):
+    def create_job(conn, source_id, status=JobStatus.QUEUED, params=None):
         jid = uuid4()
         jobs[jid] = service.Job(
             id=jid,
@@ -159,7 +159,7 @@ def test_ingest_local_ocr_failure(tmp_path, monkeypatch):
 
     jobs: dict[uuid.UUID, service.Job] = {}
 
-    def create_job(conn, source_id, status=JobStatus.QUEUED):
+    def create_job(conn, source_id, status=JobStatus.QUEUED, params=None):
         jid = uuid4()
         jobs[jid] = service.Job(
             id=jid,


### PR DESCRIPTION
## Summary
- extend `SourceType` for database and API sources and document expected `sources.params`
- add connector framework, SQL/REST implementations, and move chunking helpers into a shared module
- add `ingest_source` orchestration with storage helpers for sync state/job metadata and update tests for the new job API

## Testing
- pytest tests/test_ingestion_service.py

------
https://chatgpt.com/codex/tasks/task_e_68dd000a52d88323812f3e4449714cdc