### PR TITLE
Add connector ingestion APIs and definitions

### DIFF
--- a/app/ingestion/models.py
+++ b/app/ingestion/models.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any, Dict, Generic, List, Optional, TypeVar, TypedDict
 from uuid import UUID
 
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +107,208 @@ class TranscriptionSourceParams(TypedDict, total=False):
     job_name_prefix: str
 
 
+class ConnectorCredentials(BaseModel):
+    """Structured credentials payload supporting inline secrets and references."""
+
+    values: Dict[str, Any] | None = None
+    token: str | None = None
+    secret_id: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    def resolved(self) -> Any | None:
+        """Return the payload that should be stored with a source/definition."""
+
+        if self.values is not None:
+            return self.values
+        if self.token is not None:
+            return self.token
+        return None
+
+
+class DatabaseQuery(BaseModel):
+    """Pydantic representation of :class:`DatabaseQueryConfig`."""
+
+    name: str | None = None
+    sql: str
+    text_column: str
+    id_column: str
+    cursor_column: str | None = None
+    cursor_param: str | None = Field(default=None, alias="cursor_param")
+    initial_cursor: str | int | float | None = None
+    mime_type: str | None = None
+    document_path_template: str | None = None
+    params: Dict[str, Any] | None = None
+    extra_metadata_fields: List[str] | None = None
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    @model_validator(mode="after")
+    def _check_required_fields(self) -> "DatabaseQuery":
+        if not self.sql:
+            raise ValueError("database query requires 'sql'")
+        if not self.text_column:
+            raise ValueError("database query requires 'text_column'")
+        if not self.id_column:
+            raise ValueError("database query requires 'id_column'")
+        return self
+
+
+class DatabaseConnectorParams(BaseModel):
+    """Validated payload for database connectors."""
+
+    dsn: str | None = None
+    driver: str | None = None
+    host: str | None = None
+    port: int | None = None
+    database: str | None = None
+    user: str | None = None
+    queries: List[DatabaseQuery]
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _ensure_queries(self) -> "DatabaseConnectorParams":
+        if not self.queries:
+            raise ValueError("database connector requires at least one query")
+        return self
+
+
+class ApiPagination(BaseModel):
+    """Pagination settings for the REST connector."""
+
+    type: str | None = None
+    cursor_param: str | None = None
+    next_cursor_path: str | None = None
+    page_param: str | None = None
+    page_size_param: str | None = None
+    page_size: int | None = None
+    start_page: int | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_type(self) -> "ApiPagination":
+        if self.type and self.type not in {"cursor", "page"}:
+            raise ValueError("pagination.type must be 'cursor' or 'page'")
+        return self
+
+
+class ApiConnectorParams(BaseModel):
+    """Validated payload for REST/API connectors."""
+
+    base_url: str | None = None
+    endpoint: str | None = None
+    method: str | None = None
+    headers: Dict[str, str] | None = None
+    query_params: Dict[str, Any] | None = None
+    body: Dict[str, Any] | None = None
+    pagination: ApiPagination | None = None
+    records_path: str | None = None
+    id_field: str | None = None
+    text_fields: List[str] | None = None
+    timestamp_field: str | None = None
+    mime_type: str | None = None
+    document_path_template: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _ensure_endpoint(self) -> "ApiConnectorParams":
+        if not self.endpoint and not self.base_url:
+            raise ValueError("API connector requires an endpoint or base_url")
+        return self
+
+
+class TranscriptionConnectorParams(BaseModel):
+    """Validated payload for transcription connectors."""
+
+    provider: str
+    media_uri: str | None = None
+    cache_dir: str | None = None
+    cache_key: str | None = None
+    poll_interval: float | None = None
+    language: str | None = None
+    diarization: bool | None = None
+    whisper_model: str | None = None
+    whisper_compute_type: str | None = None
+    aws_region: str | None = None
+    aws_transcribe_params: Dict[str, Any] | None = None
+    output_mime_type: str | None = None
+    extra_metadata: Dict[str, Any] | None = None
+    segments: List[Dict[str, Any]] | None = None
+    transcript_text: str | None = None
+    cache_ttl_seconds: int | None = None
+    job_name_prefix: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class BaseConnectorJobRequest(BaseModel):
+    """Common fields for connector-backed ingestion requests."""
+
+    source_id: UUID | None = None
+    connector_definition_id: UUID | None = None
+    label: str | None = None
+    location: str | None = None
+    connector_metadata: Dict[str, Any] | None = None
+    credentials: ConnectorCredentials | Dict[str, Any] | str | None = None
+    sync_state: Dict[str, Any] | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    def _normalise_credentials(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        credentials = values.get("credentials")
+        if isinstance(credentials, ConnectorCredentials):
+            resolved = credentials.resolved()
+            if credentials.secret_id and resolved is None:
+                raise ValueError(
+                    "credentials secret_id was provided without inline payload"
+                )
+            values["credentials"] = resolved
+        return values
+
+
+class DatabaseConnectorJobRequest(BaseConnectorJobRequest):
+    """Request payload when launching a database ingestion job."""
+
+    params: DatabaseConnectorParams | None = None
+
+    @model_validator(mode="before")
+    def _normalise_params(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        params = values.get("params")
+        if isinstance(params, BaseModel):
+            values["params"] = params.model_dump(exclude_none=True)
+        return values
+
+
+class ApiConnectorJobRequest(BaseConnectorJobRequest):
+    """Request payload when launching a REST/API ingestion job."""
+
+    params: ApiConnectorParams | None = None
+
+    @model_validator(mode="before")
+    def _normalise_params(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        params = values.get("params")
+        if isinstance(params, BaseModel):
+            values["params"] = params.model_dump(exclude_none=True)
+        return values
+
+
+class TranscriptionConnectorJobRequest(BaseConnectorJobRequest):
+    """Request payload when launching a transcription ingestion job."""
+
+    params: TranscriptionConnectorParams | None = None
+
+    @model_validator(mode="before")
+    def _normalise_params(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        params = values.get("params")
+        if isinstance(params, BaseModel):
+            values["params"] = params.model_dump(exclude_none=True)
+        return values
+
+
 class JobStatus(str, Enum):
     """Lifecycle status values for an ingestion job."""
 
@@ -165,9 +367,51 @@ class SourceCreate(BaseModel):
         | None
     ) = None
     connector_type: str | None = None
-    credentials: Any | None = None
+    connector_definition_id: UUID | None = None
+    connector_metadata: Dict[str, Any] | None = None
+    credentials: ConnectorCredentials | Dict[str, Any] | str | None = None
     sync_state: dict | None = None
     version: int | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    def _normalise_payload(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        params = values.get("params")
+        if isinstance(params, BaseModel):
+            values["params"] = params.model_dump(exclude_none=True)
+        credentials = values.get("credentials")
+        if isinstance(credentials, ConnectorCredentials):
+            resolved = credentials.resolved()
+            if credentials.secret_id and resolved is None:
+                raise ValueError(
+                    "credentials secret_id was provided without inline payload"
+                )
+            values["credentials"] = resolved
+        return values
+
+    @model_validator(mode="after")
+    def _validate_params(self) -> "SourceCreate":
+        params_payload = self.params or {}
+        if self.type == SourceType.DATABASE:
+            if not params_payload:
+                raise ValueError("database source requires params")
+            DatabaseConnectorParams(**params_payload)
+            if self.connector_type is None:
+                object.__setattr__(self, "connector_type", "sql")
+        elif self.type == SourceType.API:
+            if not params_payload:
+                raise ValueError("api source requires params")
+            ApiConnectorParams(**params_payload)
+            if self.connector_type is None:
+                object.__setattr__(self, "connector_type", "rest")
+        elif self.type in {SourceType.AUDIO_TRANSCRIPT, SourceType.VIDEO_TRANSCRIPT}:
+            if not params_payload:
+                raise ValueError("transcription source requires params")
+            TranscriptionConnectorParams(**params_payload)
+            if self.connector_type is None:
+                object.__setattr__(self, "connector_type", "transcription")
+        return self
 
 
 class SourceUpdate(BaseModel):
@@ -186,9 +430,28 @@ class SourceUpdate(BaseModel):
         | None
     ) = None
     connector_type: str | None = None
-    credentials: Any | None = None
+    connector_definition_id: UUID | None = None
+    connector_metadata: Dict[str, Any] | None = None
+    credentials: ConnectorCredentials | Dict[str, Any] | str | None = None
     sync_state: dict | None = None
     version: int | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    def _normalise_payload(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        params = values.get("params")
+        if isinstance(params, BaseModel):
+            values["params"] = params.model_dump(exclude_none=True)
+        credentials = values.get("credentials")
+        if isinstance(credentials, ConnectorCredentials):
+            resolved = credentials.resolved()
+            if credentials.secret_id and resolved is None:
+                raise ValueError(
+                    "credentials secret_id was provided without inline payload"
+                )
+            values["credentials"] = resolved
+        return values
 
 
 # ---------------------------------------------------------------------------
@@ -218,11 +481,119 @@ class Source(BaseModel):
         | None
     ) = None
     connector_type: str | None = None
+    connector_definition_id: UUID | None = None
+    connector_metadata: Dict[str, Any] | None = None
     credentials: Any | None = None
     sync_state: dict | None = None
     version: int = 1
     created_at: datetime
 
+
+class ConnectorDefinitionBase(BaseModel):
+    """Shared fields for connector definitions."""
+
+    name: str
+    description: str | None = None
+    type: SourceType
+    params: (
+        DatabaseConnectorParams
+        | ApiConnectorParams
+        | TranscriptionConnectorParams
+        | Dict[str, Any]
+        | None
+    ) = None
+    credentials: ConnectorCredentials | Dict[str, Any] | str | None = None
+    metadata: Dict[str, Any] | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    def _normalise_payload(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        params = values.get("params")
+        if isinstance(params, BaseModel):
+            values["params"] = params.model_dump(exclude_none=True)
+        credentials = values.get("credentials")
+        if isinstance(credentials, ConnectorCredentials):
+            resolved = credentials.resolved()
+            if credentials.secret_id and resolved is None:
+                raise ValueError(
+                    "credentials secret_id was provided without inline payload"
+                )
+            values["credentials"] = resolved
+        return values
+
+    @model_validator(mode="after")
+    def _validate_params(self) -> "ConnectorDefinitionBase":
+        params_payload = self.params or {}
+        if self.type == SourceType.DATABASE and params_payload:
+            DatabaseConnectorParams(**params_payload)
+        elif self.type == SourceType.API and params_payload:
+            ApiConnectorParams(**params_payload)
+        elif (
+            self.type in {SourceType.AUDIO_TRANSCRIPT, SourceType.VIDEO_TRANSCRIPT}
+            and params_payload
+        ):
+            TranscriptionConnectorParams(**params_payload)
+        return self
+
+
+class ConnectorDefinitionCreate(ConnectorDefinitionBase):
+    """Payload used to create a connector definition."""
+
+    @model_validator(mode="after")
+    def _require_params(self) -> "ConnectorDefinitionCreate":
+        if self.type == SourceType.DATABASE and not self.params:
+            raise ValueError("database connector definition requires params")
+        if self.type == SourceType.API and not self.params:
+            raise ValueError("api connector definition requires params")
+        if (
+            self.type in {SourceType.AUDIO_TRANSCRIPT, SourceType.VIDEO_TRANSCRIPT}
+            and not self.params
+        ):
+            raise ValueError("transcription connector definition requires params")
+        return self
+
+
+class ConnectorDefinitionUpdate(BaseModel):
+    """Payload used to update a connector definition."""
+
+    name: str | None = None
+    description: str | None = None
+    params: (
+        DatabaseConnectorParams
+        | ApiConnectorParams
+        | TranscriptionConnectorParams
+        | Dict[str, Any]
+        | None
+    ) = None
+    credentials: ConnectorCredentials | Dict[str, Any] | str | None = None
+    metadata: Dict[str, Any] | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    def _normalise_payload(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        params = values.get("params")
+        if isinstance(params, BaseModel):
+            values["params"] = params.model_dump(exclude_none=True)
+        credentials = values.get("credentials")
+        if isinstance(credentials, ConnectorCredentials):
+            resolved = credentials.resolved()
+            if credentials.secret_id and resolved is None:
+                raise ValueError(
+                    "credentials secret_id was provided without inline payload"
+                )
+            values["credentials"] = resolved
+        return values
+
+
+class ConnectorDefinition(ConnectorDefinitionBase):
+    """Representation of a stored connector definition."""
+
+    id: UUID
+    created_at: datetime
+    updated_at: datetime | None = None
+    has_credentials: bool = False
 
 class Job(BaseModel):
     id: UUID

--- a/app/routers/admin_ingest_api.py
+++ b/app/routers/admin_ingest_api.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 from uuid import UUID
 
 import psycopg
@@ -18,6 +18,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ..ingestion import service, storage
 from ..ingestion.models import (
+    ApiConnectorJobRequest,
+    ConnectorDefinition,
+    ConnectorDefinitionCreate,
+    ConnectorDefinitionUpdate,
+    DatabaseConnectorJobRequest,
     Job,
     JobCreated,
     JobLogSlice,
@@ -28,6 +33,7 @@ from ..ingestion.models import (
     SourceCreate,
     SourceType,
     SourceUpdate,
+    TranscriptionConnectorJobRequest,
     UrlIngestRequest,
     UrlsIngestRequest,
 )
@@ -53,6 +59,126 @@ def _fetch_source(conn: psycopg.Connection, source_id: UUID) -> Source:
         if src.id == source_id:
             return src
     raise HTTPException(status_code=404, detail="Source not found")
+
+
+def _ensure_connector_definition(
+    conn: psycopg.Connection,
+    definition_id: UUID,
+    expected_type: SourceType | set[SourceType],
+) -> ConnectorDefinition:
+    definition = storage.get_connector_definition(
+        conn,
+        definition_id,
+        include_credentials=True,
+    )
+    if not definition:
+        raise HTTPException(status_code=404, detail="Connector definition not found")
+    allowed_types = (
+        {expected_type}
+        if isinstance(expected_type, SourceType)
+        else set(expected_type)
+    )
+    if definition.type not in allowed_types:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Connector definition type mismatch: "
+                f"expected {[t.value for t in sorted(allowed_types, key=lambda t: t.value)]} "
+                f"got {definition.type.value}"
+            ),
+        )
+    return definition
+
+
+def _resolve_credentials(
+    provided: object | None,
+    fallback: object | None,
+    *,
+    required: bool,
+) -> object | None:
+    credentials = provided if provided is not None else fallback
+    if isinstance(credentials, dict) and set(credentials.keys()) == {"secret_id"}:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Credentials references must be resolved and stored before starting a job"
+            ),
+        )
+    if required and credentials is None:
+        raise HTTPException(status_code=400, detail="Credentials are required for this connector")
+    return credentials
+
+
+def _ensure_params_for_type(source_type: SourceType, params: Dict[str, Any] | None) -> Dict[str, Any]:
+    if not params:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{source_type.value} connector requires configuration parameters",
+        )
+    if source_type == SourceType.DATABASE and not params.get("queries"):
+        raise HTTPException(
+            status_code=400,
+            detail="Database connector requires at least one query",
+        )
+    if source_type == SourceType.API and not (params.get("endpoint") or params.get("base_url")):
+        raise HTTPException(
+            status_code=400,
+            detail="API connector requires an endpoint or base_url",
+        )
+    if source_type in {SourceType.AUDIO_TRANSCRIPT, SourceType.VIDEO_TRANSCRIPT} and not params.get("provider"):
+        raise HTTPException(
+            status_code=400,
+            detail="Transcription connector requires a provider",
+        )
+    return dict(params)
+
+
+def _upsert_source_for_connector(
+    conn: psycopg.Connection,
+    *,
+    source_id: UUID | None,
+    source_type: SourceType,
+    params: Dict[str, Any],
+    connector_type: str,
+    connector_definition_id: UUID | None,
+    connector_metadata: Dict[str, Any] | None,
+    credentials: object | None,
+    label: str | None,
+    location: str | None,
+    sync_state: Dict[str, Any] | None,
+) -> UUID:
+    if source_id:
+        existing = storage.get_source(conn, source_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="Source not found")
+        if existing.type != source_type:
+            raise HTTPException(status_code=400, detail="Source type mismatch")
+        storage.update_source(
+            conn,
+            source_id,
+            label=label,
+            location=location,
+            params=params,
+            connector_type=connector_type,
+            connector_definition_id=connector_definition_id,
+            connector_metadata=connector_metadata,
+            credentials=credentials,
+            sync_state=sync_state,
+        )
+        return source_id
+
+    return storage.get_or_create_source(
+        conn,
+        type=source_type,
+        label=label,
+        location=location,
+        params=params,
+        connector_type=connector_type,
+        connector_definition_id=connector_definition_id,
+        connector_metadata=connector_metadata,
+        credentials=credentials,
+        sync_state=sync_state,
+    )
 
 
 @router.post("/local", response_model=JobCreated)
@@ -95,6 +221,257 @@ def start_urls_job(
 ) -> JobCreated:
     job_id = service.ingest_urls([str(u) for u in req.urls])
     return JobCreated(job_id=job_id)
+
+
+@router.post("/database", response_model=JobCreated)
+def start_database_connector_job(
+    req: DatabaseConnectorJobRequest,
+    role: str = Depends(require_role("operator")),
+) -> JobCreated:
+    with _get_conn() as conn:
+        definition = (
+            _ensure_connector_definition(conn, req.connector_definition_id, SourceType.DATABASE)
+            if req.connector_definition_id
+            else None
+        )
+        params_source = req.params or (definition.params if definition else None)
+        params = _ensure_params_for_type(SourceType.DATABASE, params_source)
+        credentials = _resolve_credentials(
+            req.credentials,
+            definition.credentials if definition else None,
+            required=True,
+        )
+        metadata = req.connector_metadata
+        if metadata is None and definition and definition.metadata is not None:
+            metadata = dict(definition.metadata)
+        label = req.label or (definition.name if definition else None)
+        location = req.location
+        if location is None and metadata and isinstance(metadata, dict):
+            location = metadata.get("location")
+        source_id = _upsert_source_for_connector(
+            conn,
+            source_id=req.source_id,
+            source_type=SourceType.DATABASE,
+            params=params,
+            connector_type="sql",
+            connector_definition_id=req.connector_definition_id,
+            connector_metadata=metadata,
+            credentials=credentials,
+            label=label,
+            location=location,
+            sync_state=req.sync_state,
+        )
+    job_id = service.ingest_source(source_id)
+    return JobCreated(job_id=job_id)
+
+
+@router.post("/api", response_model=JobCreated)
+def start_api_connector_job(
+    req: ApiConnectorJobRequest,
+    role: str = Depends(require_role("operator")),
+) -> JobCreated:
+    with _get_conn() as conn:
+        definition = (
+            _ensure_connector_definition(conn, req.connector_definition_id, SourceType.API)
+            if req.connector_definition_id
+            else None
+        )
+        params_source = req.params or (definition.params if definition else None)
+        params = _ensure_params_for_type(SourceType.API, params_source)
+        credentials = _resolve_credentials(
+            req.credentials,
+            definition.credentials if definition else None,
+            required=False,
+        )
+        metadata = req.connector_metadata
+        if metadata is None and definition and definition.metadata is not None:
+            metadata = dict(definition.metadata)
+        label = req.label or (definition.name if definition else None)
+        location = req.location
+        if location is None and metadata and isinstance(metadata, dict):
+            location = metadata.get("location")
+        source_id = _upsert_source_for_connector(
+            conn,
+            source_id=req.source_id,
+            source_type=SourceType.API,
+            params=params,
+            connector_type="rest",
+            connector_definition_id=req.connector_definition_id,
+            connector_metadata=metadata,
+            credentials=credentials,
+            label=label,
+            location=location,
+            sync_state=req.sync_state,
+        )
+    job_id = service.ingest_source(source_id)
+    return JobCreated(job_id=job_id)
+
+
+@router.post("/transcription", response_model=JobCreated)
+def start_transcription_connector_job(
+    req: TranscriptionConnectorJobRequest,
+    role: str = Depends(require_role("operator")),
+) -> JobCreated:
+    with _get_conn() as conn:
+        if req.connector_definition_id:
+            definition = _ensure_connector_definition(
+                conn,
+                req.connector_definition_id,
+                {SourceType.AUDIO_TRANSCRIPT, SourceType.VIDEO_TRANSCRIPT},
+            )
+            expected_type = definition.type
+        else:
+            definition = None
+            expected_type = SourceType.AUDIO_TRANSCRIPT
+            if req.connector_metadata and req.connector_metadata.get("media_type") == "video":
+                expected_type = SourceType.VIDEO_TRANSCRIPT
+        params_source = req.params or (definition.params if definition else None)
+        params = _ensure_params_for_type(expected_type, params_source)
+        credentials = _resolve_credentials(
+            req.credentials,
+            definition.credentials if definition else None,
+            required=False,
+        )
+        metadata = req.connector_metadata
+        if metadata is None and definition and definition.metadata is not None:
+            metadata = dict(definition.metadata)
+        label = req.label or (definition.name if definition else None)
+        location = req.location
+        if location is None and metadata and isinstance(metadata, dict):
+            location = metadata.get("location")
+        source_id = _upsert_source_for_connector(
+            conn,
+            source_id=req.source_id,
+            source_type=expected_type,
+            params=params,
+            connector_type="transcription",
+            connector_definition_id=req.connector_definition_id,
+            connector_metadata=metadata,
+            credentials=credentials,
+            label=label,
+            location=location,
+            sync_state=req.sync_state,
+        )
+    job_id = service.ingest_source(source_id)
+    return JobCreated(job_id=job_id)
+
+
+@router.get("/connector_definitions", response_model=ListResponse[ConnectorDefinition])
+def list_connector_definitions(
+    type: SourceType | None = Query(default=None),
+    limit: int | None = Query(default=None, ge=1),
+    offset: int = Query(default=0, ge=0),
+    role: str = Depends(require_role("viewer")),
+) -> ListResponse[ConnectorDefinition]:
+    with _get_conn() as conn:
+        all_defs = list(
+            storage.list_connector_definitions(
+                conn,
+                type=type,
+                include_credentials=False,
+            )
+        )
+    total = len(all_defs)
+    items = all_defs[offset:]
+    if limit is not None:
+        items = items[:limit]
+    return ListResponse[ConnectorDefinition](items=items, total=total)
+
+
+@router.post("/connector_definitions", response_model=ConnectorDefinition)
+def create_connector_definition_endpoint(
+    req: ConnectorDefinitionCreate,
+    role: str = Depends(require_role("operator")),
+) -> ConnectorDefinition:
+    with _get_conn() as conn:
+        definition_id = storage.create_connector_definition(
+            conn,
+            name=req.name,
+            type=req.type,
+            description=req.description,
+            params=req.params,
+            credentials=req.credentials,
+            metadata=req.metadata,
+        )
+        created = storage.get_connector_definition(
+            conn,
+            definition_id,
+            include_credentials=False,
+        )
+    if not created:
+        raise HTTPException(status_code=500, detail="Failed to create connector definition")
+    return created
+
+
+@router.get("/connector_definitions/{definition_id}", response_model=ConnectorDefinition)
+def get_connector_definition_endpoint(
+    definition_id: UUID,
+    role: str = Depends(require_role("viewer")),
+) -> ConnectorDefinition:
+    with _get_conn() as conn:
+        definition = storage.get_connector_definition(
+            conn,
+            definition_id,
+            include_credentials=False,
+        )
+    if not definition:
+        raise HTTPException(status_code=404, detail="Connector definition not found")
+    return definition
+
+
+@router.put("/connector_definitions/{definition_id}", response_model=ConnectorDefinition)
+def update_connector_definition_endpoint(
+    definition_id: UUID,
+    req: ConnectorDefinitionUpdate,
+    role: str = Depends(require_role("operator")),
+) -> ConnectorDefinition:
+    with _get_conn() as conn:
+        existing = storage.get_connector_definition(
+            conn,
+            definition_id,
+            include_credentials=True,
+        )
+        if not existing:
+            raise HTTPException(status_code=404, detail="Connector definition not found")
+        credentials_param: object
+        if "credentials" in req.model_fields_set:
+            credentials_param = req.credentials
+        else:
+            credentials_param = getattr(storage, "_MISSING")
+        storage.update_connector_definition(
+            conn,
+            definition_id,
+            name=req.name,
+            description=req.description,
+            params=req.params,
+            credentials=credentials_param,
+            metadata=req.metadata,
+        )
+        updated = storage.get_connector_definition(
+            conn,
+            definition_id,
+            include_credentials=False,
+        )
+    if not updated:
+        raise HTTPException(status_code=500, detail="Failed to update connector definition")
+    return updated
+
+
+@router.delete("/connector_definitions/{definition_id}", response_model=ConnectorDefinition)
+def delete_connector_definition_endpoint(
+    definition_id: UUID,
+    role: str = Depends(require_role("operator")),
+) -> ConnectorDefinition:
+    with _get_conn() as conn:
+        definition = storage.get_connector_definition(
+            conn,
+            definition_id,
+            include_credentials=False,
+        )
+        if not definition:
+            raise HTTPException(status_code=404, detail="Connector definition not found")
+        storage.delete_connector_definition(conn, definition_id)
+    return definition
 
 
 @router.get("/jobs", response_model=ListResponse[Job])
@@ -191,6 +568,8 @@ def create_source(
             active=req.active,
             params=req.params,
             connector_type=req.connector_type,
+            connector_definition_id=req.connector_definition_id,
+            connector_metadata=req.connector_metadata,
             credentials=req.credentials,
             sync_state=req.sync_state,
             version=req.version,
@@ -215,6 +594,8 @@ def update_source(
             active=req.active,
             params=req.params,
             connector_type=req.connector_type,
+            connector_definition_id=req.connector_definition_id,
+            connector_metadata=req.connector_metadata,
             credentials=req.credentials,
             sync_state=req.sync_state,
             version=req.version,

--- a/migrations/009_connector_definitions.sql
+++ b/migrations/009_connector_definitions.sql
@@ -1,0 +1,18 @@
+-- Create connector definitions catalogue and link it to sources
+CREATE TABLE IF NOT EXISTS connector_definitions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    description TEXT,
+    params JSONB,
+    credentials BYTEA,
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_definitions_type ON connector_definitions (type);
+
+ALTER TABLE sources
+    ADD COLUMN IF NOT EXISTS connector_definition_id UUID REFERENCES connector_definitions(id),
+    ADD COLUMN IF NOT EXISTS connector_metadata JSONB;

--- a/schema.sql
+++ b/schema.sql
@@ -9,6 +9,21 @@
 CREATE EXTENSION IF NOT EXISTS pgcrypto; -- for gen_random_uuid
 CREATE EXTENSION IF NOT EXISTS vector;
 
+-- Connector definitions -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS connector_definitions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  description TEXT,
+  params JSONB,
+  credentials BYTEA,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_definitions_type ON connector_definitions (type);
+
 -- Ingestion sources ---------------------------------------------------------
 CREATE TABLE IF NOT EXISTS sources (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -19,6 +34,8 @@ CREATE TABLE IF NOT EXISTS sources (
   url TEXT,
   params JSONB,
   connector_type TEXT,
+  connector_definition_id UUID REFERENCES connector_definitions(id),
+  connector_metadata JSONB,
   credentials BYTEA,
   sync_state JSONB,
   version INTEGER NOT NULL DEFAULT 1,


### PR DESCRIPTION
## Summary
- add typed connector request models and connector definition schemas for reuse across ingestion
- store connector metadata and definitions, including credentials, via new storage helpers and schema changes
- expose admin API routes for database, API, and transcription jobs alongside CRUD endpoints for connector definitions and document RBAC/credential guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd11101554832396271f490ff69113