### PR TITLE
Add multi-channel webhooks and conversation management

### DIFF
--- a/app/agents/schemas.py
+++ b/app/agents/schemas.py
@@ -153,6 +153,30 @@ class AgentDeployResponse(AgentDetail):
     pass
 
 
+
+
+class ChannelConfig(BaseModel):
+    channel: str
+    is_enabled: bool = True
+    webhook_secret: Optional[str] = None
+    credentials: Dict[str, Any] = Field(default_factory=dict)
+    settings: Dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+
+
+class ChannelConfigUpdate(BaseModel):
+    is_enabled: Optional[bool] = None
+    webhook_secret: Optional[str] = None
+    credentials: Optional[Dict[str, Any]] = None
+    settings: Optional[Dict[str, Any]] = None
+
+
+class ChannelConfigList(BaseModel):
+    items: List[ChannelConfig]
+    total: int
+
+
 class Message(BaseModel):
     message: str
 

--- a/app/channels/__init__.py
+++ b/app/channels/__init__.py
@@ -1,0 +1,30 @@
+"""Channel adapter registry for multi-channel messaging support."""
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import ChannelAdapter
+from .telegram import TelegramAdapter
+from .whatsapp import WhatsAppAdapter
+
+_REGISTRY: Dict[str, Type[ChannelAdapter]] = {}
+
+
+def register_adapter(adapter: Type[ChannelAdapter]) -> None:
+    """Register a channel adapter class in the global registry."""
+    _REGISTRY[adapter.channel_name] = adapter
+
+
+def get_adapter(name: str) -> Type[ChannelAdapter]:
+    """Retrieve an adapter class for ``name`` or raise ``KeyError``."""
+    normalized = name.lower()
+    if normalized not in _REGISTRY:
+        raise KeyError(f"Channel '{name}' is not configured")
+    return _REGISTRY[normalized]
+
+
+# Pre-register built-in adapters
+register_adapter(WhatsAppAdapter)
+register_adapter(TelegramAdapter)
+
+__all__ = ["ChannelAdapter", "get_adapter", "register_adapter"]

--- a/app/channels/base.py
+++ b/app/channels/base.py
@@ -1,0 +1,48 @@
+"""Base abstractions for chat channel adapters."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable, Mapping
+
+from ..conversations.models import NormalizedMessage
+
+
+class ChannelAdapter(ABC):
+    """Abstract base class encapsulating channel-specific behaviour."""
+
+    #: Lowercase channel identifier used in routes and configuration.
+    channel_name: str
+
+    def __init__(self, *, agent_id: int) -> None:
+        self.agent_id = agent_id
+
+    @abstractmethod
+    def parse_incoming(
+        self,
+        payload: Mapping[str, Any],
+        headers: Mapping[str, str],
+        config: Mapping[str, Any],
+    ) -> Iterable[NormalizedMessage]:
+        """Convert a webhook payload into normalized messages."""
+
+    def verify_signature(
+        self,
+        body: bytes,
+        headers: Mapping[str, str],
+        config: Mapping[str, Any],
+    ) -> bool:
+        """Validate authenticity of the webhook payload.
+
+        Adapters can override this to implement signature checks. The default
+        implementation returns ``True``.
+        """
+
+        return True
+
+    def build_outgoing_payload(self, message: Dict[str, Any], config: Mapping[str, Any]) -> Dict[str, Any]:
+        """Prepare an outbound payload for the channel API.
+
+        The default implementation simply returns the message unchanged.
+        """
+
+        return message

--- a/app/channels/telegram.py
+++ b/app/channels/telegram.py
@@ -1,0 +1,93 @@
+"""Telegram channel adapter."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Mapping
+
+from .base import ChannelAdapter
+from ..conversations.models import NormalizedMessage
+
+
+class TelegramAdapter(ChannelAdapter):
+    channel_name = "telegram"
+
+    def verify_signature(
+        self,
+        body: bytes,
+        headers: Mapping[str, str],
+        config: Mapping[str, Any],
+    ) -> bool:
+        secret = (config or {}).get("secret_token")
+        if not secret:
+            return True
+        received = headers.get("X-Telegram-Bot-Api-Secret-Token")
+        return bool(received and received == secret)
+
+    def parse_incoming(
+        self,
+        payload: Mapping[str, Any],
+        headers: Mapping[str, str],
+        config: Mapping[str, Any],
+    ) -> Iterable[NormalizedMessage]:
+        message = payload.get("message") or payload.get("edited_message")
+        if message:
+            yield self._from_message(message)
+            return
+        callback = payload.get("callback_query")
+        if callback:
+            data = callback.get("data") or ""
+            message = callback.get("message") or {}
+            chat = message.get("chat", {})
+            user = callback.get("from") or {}
+            sent_at = datetime.fromtimestamp(callback.get("date", datetime.now(timezone.utc).timestamp()), tz=timezone.utc)
+            yield NormalizedMessage(
+                agent_id=self.agent_id,
+                channel=self.channel_name,
+                external_conversation_id=str(chat.get("id")),
+                sender_id=str(user.get("id")),
+                sender_role="customer",
+                sender_name=self._display_name(user),
+                text=data,
+                attachments=[],
+                metadata={"callback_query": callback},
+                sent_at=sent_at,
+            )
+
+    def _from_message(self, message: Mapping[str, Any]) -> NormalizedMessage:
+        chat = message.get("chat", {})
+        user = message.get("from") or {}
+        text = message.get("text") or message.get("caption") or ""
+        attachments = []
+        if message.get("photo"):
+            attachments.append({"type": "photo", "sizes": message.get("photo")})
+        if message.get("document"):
+            attachments.append({"type": "document", **message.get("document")})
+        if message.get("voice"):
+            attachments.append({"type": "voice", **message.get("voice")})
+        timestamp = message.get("date")
+        if timestamp:
+            sent_at = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        else:
+            sent_at = datetime.now(timezone.utc)
+        metadata: Dict[str, Any] = {
+            "message_id": message.get("message_id"),
+            "entities": message.get("entities"),
+            "chat": chat,
+        }
+        return NormalizedMessage(
+            agent_id=self.agent_id,
+            channel=self.channel_name,
+            external_conversation_id=str(chat.get("id")),
+            sender_id=str(user.get("id")),
+            sender_role="customer",
+            sender_name=self._display_name(user),
+            text=text,
+            attachments=attachments,
+            metadata=metadata,
+            sent_at=sent_at,
+        )
+
+    def _display_name(self, user: Mapping[str, Any]) -> str:
+        return user.get("username") or " ".join(
+            filter(None, [user.get("first_name"), user.get("last_name")])
+        ).strip()

--- a/app/channels/whatsapp.py
+++ b/app/channels/whatsapp.py
@@ -1,0 +1,88 @@
+"""WhatsApp channel adapter."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+
+from .base import ChannelAdapter
+from ..conversations.models import NormalizedMessage
+
+
+class WhatsAppAdapter(ChannelAdapter):
+    channel_name = "whatsapp"
+
+    def verify_signature(
+        self,
+        body: bytes,
+        headers: Mapping[str, str],
+        config: Mapping[str, Any],
+    ) -> bool:
+        secret = (config or {}).get("webhook_secret")
+        if not secret:
+            return True
+        received = headers.get("X-Hub-Signature-256")
+        if not received:
+            return False
+        digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+        expected = f"sha256={digest}"
+        return hmac.compare_digest(received, expected)
+
+    def parse_incoming(
+        self,
+        payload: Mapping[str, Any],
+        headers: Mapping[str, str],
+        config: Mapping[str, Any],
+    ) -> Iterable[NormalizedMessage]:
+        entries = payload.get("entry", [])
+        for entry in entries:
+            for change in entry.get("changes", []):
+                value = change.get("value", {})
+                contacts = {c.get("wa_id"): c for c in value.get("contacts", [])}
+                for message in value.get("messages", []):
+                    sender_id = message.get("from") or ""
+                    contact = contacts.get(sender_id, {})
+                    name = contact.get("profile", {}).get("name")
+                    text = ""
+                    attachments = []
+                    message_type = message.get("type")
+                    if message_type == "text":
+                        text = (message.get("text") or {}).get("body", "")
+                    elif message_type in {"image", "audio", "video", "document"}:
+                        media = message.get(message_type, {})
+                        attachments.append({"type": message_type, **media})
+                        text = media.get("caption", "")
+                    elif message_type == "interactive":
+                        interactive = message.get("interactive", {})
+                        text = interactive.get("text") or interactive.get("title") or ""
+                    conversation_id = (
+                        (message.get("context") or {}).get("id")
+                        or value.get("metadata", {}).get("phone_number_id")
+                        or sender_id
+                    )
+                    timestamp = message.get("timestamp")
+                    if timestamp:
+                        try:
+                            sent_at = datetime.fromtimestamp(int(timestamp), tz=timezone.utc)
+                        except (ValueError, TypeError):
+                            sent_at = datetime.now(timezone.utc)
+                    else:
+                        sent_at = datetime.now(timezone.utc)
+                    metadata = {
+                        "channel_payload": message,
+                        "sender": contact,
+                        "wa_business_account": value.get("metadata", {}),
+                    }
+                    yield NormalizedMessage(
+                        agent_id=self.agent_id,
+                        channel=self.channel_name,
+                        external_conversation_id=str(conversation_id),
+                        sender_id=str(sender_id),
+                        sender_role="customer",
+                        sender_name=name,
+                        text=text,
+                        attachments=attachments,
+                        metadata=metadata,
+                        sent_at=sent_at,
+                    )

--- a/app/conversations/__init__.py
+++ b/app/conversations/__init__.py
@@ -1,0 +1,12 @@
+"""Conversation flow services and schemas."""
+from .models import NormalizedMessage, EscalationDecision, FollowUpDecision
+from .service import ConversationService
+from . import schemas
+
+__all__ = [
+    "ConversationService",
+    "EscalationDecision",
+    "FollowUpDecision",
+    "NormalizedMessage",
+    "schemas",
+]

--- a/app/conversations/models.py
+++ b/app/conversations/models.py
@@ -1,0 +1,35 @@
+"""Domain models used by the conversation service."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class NormalizedMessage:
+    """Uniform representation of inbound channel messages."""
+
+    agent_id: int
+    channel: str
+    external_conversation_id: str
+    sender_id: str
+    sender_role: str
+    text: str
+    sender_name: Optional[str] = None
+    attachments: List[Dict[str, Any]] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    sent_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class EscalationDecision:
+    should_escalate: bool
+    reason: Optional[str] = None
+    escalate_to: Optional[str] = None
+
+
+@dataclass
+class FollowUpDecision:
+    follow_up_at: Optional[datetime]
+    note: Optional[str] = None

--- a/app/conversations/repository.py
+++ b/app/conversations/repository.py
@@ -1,0 +1,349 @@
+"""Database repository for conversations."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Protocol
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from . import schemas
+
+
+class ConversationRepository(Protocol):
+    """Abstraction for persisting conversation artefacts."""
+
+    def get_by_external(
+        self, agent_id: int, channel: str, external_conversation_id: str
+    ) -> Optional[schemas.ConversationDetail]: ...
+
+    def create_conversation(
+        self,
+        agent_id: int,
+        channel: str,
+        external_conversation_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> schemas.ConversationDetail: ...
+
+    def add_participant(
+        self,
+        conversation_id: int,
+        role: str,
+        external_id: Optional[str],
+        display_name: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> schemas.ConversationParticipant: ...
+
+    def get_participant(
+        self,
+        conversation_id: int,
+        role: str,
+        external_id: Optional[str],
+    ) -> Optional[schemas.ConversationParticipant]: ...
+
+    def add_message(
+        self,
+        conversation_id: int,
+        participant_id: Optional[int],
+        direction: str,
+        body: Dict[str, Any],
+        nlp: Dict[str, Any],
+        sent_at: datetime,
+    ) -> schemas.ConversationMessage: ...
+
+    def update_conversation_touch(
+        self,
+        conversation_id: int,
+        *,
+        last_message_at: datetime,
+        status: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None: ...
+
+    def list_conversations(self, agent_id: int, limit: int = 50) -> List[schemas.ConversationSummary]: ...
+
+    def get_conversation(self, conversation_id: int) -> Optional[schemas.ConversationDetail]: ...
+
+    def set_follow_up(
+        self,
+        conversation_id: int,
+        follow_up_at: Optional[datetime],
+        note: Optional[str],
+    ) -> None: ...
+
+    def mark_escalated(
+        self,
+        conversation_id: int,
+        *,
+        is_escalated: bool,
+        reason: Optional[str],
+        escalate_to: Optional[str],
+    ) -> None: ...
+
+    def analytics(self, agent_id: int) -> schemas.ConversationAnalytics: ...
+
+    def channel_analytics(self, agent_id: int) -> List[schemas.ChannelConfigAnalytics]: ...
+
+
+class PostgresConversationRepository:
+    """PostgreSQL implementation of :class:`ConversationRepository`."""
+
+    def __init__(self, conn: psycopg.Connection):
+        self._conn = conn
+
+    # Utility -----------------------------------------------------------------
+    def _cursor(self):
+        return self._conn.cursor(row_factory=dict_row)
+
+    # Conversation operations --------------------------------------------------
+    def get_by_external(
+        self, agent_id: int, channel: str, external_conversation_id: str
+    ) -> Optional[schemas.ConversationDetail]:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                SELECT * FROM conversations
+                WHERE agent_id = %s AND channel = %s AND external_conversation_id = %s
+                """,
+                (agent_id, channel, external_conversation_id),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None
+        return self._hydrate_conversation(row)
+
+    def create_conversation(
+        self,
+        agent_id: int,
+        channel: str,
+        external_conversation_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> schemas.ConversationDetail:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO conversations (agent_id, channel, external_conversation_id, metadata)
+                VALUES (%s, %s, %s, %s)
+                RETURNING *
+                """,
+                (agent_id, channel, external_conversation_id, Jsonb(metadata or {})),
+            )
+            row = cur.fetchone()
+        return self._hydrate_conversation(row)
+
+    def add_participant(
+        self,
+        conversation_id: int,
+        role: str,
+        external_id: Optional[str],
+        display_name: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> schemas.ConversationParticipant:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO conversation_participants
+                    (conversation_id, role, external_id, display_name, metadata)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING *
+                """,
+                (conversation_id, role, external_id, display_name, Jsonb(metadata or {})),
+            )
+            row = cur.fetchone()
+        return schemas.ConversationParticipant(**row)
+
+    def get_participant(
+        self,
+        conversation_id: int,
+        role: str,
+        external_id: Optional[str],
+    ) -> Optional[schemas.ConversationParticipant]:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                SELECT * FROM conversation_participants
+                WHERE conversation_id = %s AND role = %s AND coalesce(external_id, '') = coalesce(%s, '')
+                ORDER BY created_at ASC
+                LIMIT 1
+                """,
+                (conversation_id, role, external_id),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None
+        return schemas.ConversationParticipant(**row)
+
+    def add_message(
+        self,
+        conversation_id: int,
+        participant_id: Optional[int],
+        direction: str,
+        body: Dict[str, Any],
+        nlp: Dict[str, Any],
+        sent_at: datetime,
+    ) -> schemas.ConversationMessage:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO conversation_messages
+                    (conversation_id, participant_id, direction, body, nlp, sent_at)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                RETURNING *
+                """,
+                (
+                    conversation_id,
+                    participant_id,
+                    direction,
+                    Jsonb(body),
+                    Jsonb(nlp),
+                    sent_at,
+                ),
+            )
+            row = cur.fetchone()
+        return schemas.ConversationMessage(**row)
+
+    def update_conversation_touch(
+        self,
+        conversation_id: int,
+        *,
+        last_message_at: datetime,
+        status: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        fields: List[str] = ["last_message_at = %s"]
+        values: List[Any] = [last_message_at]
+        if status is not None:
+            fields.append("status = %s")
+            values.append(status)
+        if metadata is not None:
+            fields.append("metadata = %s")
+            values.append(Jsonb(metadata))
+        values.append(conversation_id)
+        query = f"UPDATE conversations SET {', '.join(fields)}, updated_at = now() WHERE id = %s"
+        with self._cursor() as cur:
+            cur.execute(query, values)
+
+    def list_conversations(self, agent_id: int, limit: int = 50) -> List[schemas.ConversationSummary]:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, agent_id, channel, external_conversation_id, status, is_escalated,
+                       escalation_reason, follow_up_at, follow_up_note, last_message_at, metadata
+                FROM conversations
+                WHERE agent_id = %s
+                ORDER BY last_message_at DESC NULLS LAST, created_at DESC
+                LIMIT %s
+                """,
+                (agent_id, limit),
+            )
+            rows = cur.fetchall()
+        return [schemas.ConversationSummary(**row) for row in rows]
+
+    def get_conversation(self, conversation_id: int) -> Optional[schemas.ConversationDetail]:
+        with self._cursor() as cur:
+            cur.execute("SELECT * FROM conversations WHERE id = %s", (conversation_id,))
+            convo = cur.fetchone()
+            if not convo:
+                return None
+            cur.execute(
+                "SELECT * FROM conversation_participants WHERE conversation_id = %s ORDER BY created_at",
+                (conversation_id,),
+            )
+            participants = [schemas.ConversationParticipant(**row) for row in cur.fetchall()]
+            cur.execute(
+                """
+                SELECT * FROM conversation_messages
+                WHERE conversation_id = %s
+                ORDER BY sent_at ASC
+                """,
+                (conversation_id,),
+            )
+            messages = [schemas.ConversationMessage(**row) for row in cur.fetchall()]
+        detail = self._hydrate_conversation(convo)
+        detail.participants = participants
+        detail.messages = messages
+        return detail
+
+    def set_follow_up(
+        self,
+        conversation_id: int,
+        follow_up_at: Optional[datetime],
+        note: Optional[str],
+    ) -> None:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                UPDATE conversations
+                SET follow_up_at = %s, follow_up_note = %s, updated_at = now()
+                WHERE id = %s
+                """,
+                (follow_up_at, note, conversation_id),
+            )
+
+    def mark_escalated(
+        self,
+        conversation_id: int,
+        *,
+        is_escalated: bool,
+        reason: Optional[str],
+        escalate_to: Optional[str],
+    ) -> None:
+        metadata_updates: Dict[str, Any] = {}
+        if escalate_to:
+            metadata_updates["escalated_to"] = escalate_to
+        set_clause = ["is_escalated = %s", "escalation_reason = %s"]
+        params: List[Any] = [is_escalated, reason]
+        if metadata_updates:
+            set_clause.append("metadata = metadata || %s")
+            params.append(Jsonb(metadata_updates))
+        params.append(conversation_id)
+        query = f"UPDATE conversations SET {', '.join(set_clause)}, escalated_at = now(), updated_at = now() WHERE id = %s"
+        with self._cursor() as cur:
+            cur.execute(query, params)
+
+    def analytics(self, agent_id: int) -> schemas.ConversationAnalytics:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    COUNT(*) FILTER (WHERE status = 'open') AS open,
+                    COUNT(*) FILTER (WHERE is_escalated) AS escalated,
+                    COUNT(*) FILTER (WHERE follow_up_at IS NOT NULL AND follow_up_at > now()) AS follow_ups
+                FROM conversations
+                WHERE agent_id = %s
+                """,
+                (agent_id,),
+            )
+            row = cur.fetchone() or {"open": 0, "escalated": 0, "follow_ups": 0}
+        return schemas.ConversationAnalytics(
+            open_conversations=row["open"],
+            escalated_conversations=row["escalated"],
+            pending_follow_ups=row["follow_ups"],
+        )
+
+    def channel_analytics(self, agent_id: int) -> List[schemas.ChannelConfigAnalytics]:
+        with self._cursor() as cur:
+            cur.execute(
+                """
+                SELECT channel,
+                       COUNT(*) AS conversations,
+                       COUNT(*) FILTER (WHERE is_escalated) AS escalations,
+                       MAX(last_message_at) AS last_activity
+                FROM conversations
+                WHERE agent_id = %s
+                GROUP BY channel
+                ORDER BY channel
+                """,
+                (agent_id,),
+            )
+            rows = cur.fetchall()
+        return [schemas.ChannelConfigAnalytics(**row) for row in rows]
+
+    # Helpers ------------------------------------------------------------------
+    def _hydrate_conversation(self, row: Dict[str, Any]) -> schemas.ConversationDetail:
+        data = dict(row)
+        detail = schemas.ConversationDetail(**data)
+        detail.participants = []
+        detail.messages = []
+        return detail

--- a/app/conversations/schemas.py
+++ b/app/conversations/schemas.py
@@ -1,0 +1,94 @@
+"""Pydantic schemas for conversation management APIs."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ConversationParticipant(BaseModel):
+    id: int
+    conversation_id: int
+    role: str
+    external_id: Optional[str] = None
+    display_name: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+
+
+class ConversationMessage(BaseModel):
+    id: int
+    conversation_id: int
+    participant_id: Optional[int] = None
+    direction: str
+    body: Dict[str, Any] = Field(default_factory=dict)
+    nlp: Dict[str, Any] = Field(default_factory=dict)
+    sent_at: datetime
+
+
+class ConversationSummary(BaseModel):
+    id: int
+    agent_id: int
+    channel: str
+    external_conversation_id: str
+    status: str
+    is_escalated: bool
+    escalation_reason: Optional[str] = None
+    follow_up_at: Optional[datetime] = None
+    follow_up_note: Optional[str] = None
+    last_message_at: Optional[datetime] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ConversationDetail(ConversationSummary):
+    participants: List[ConversationParticipant] = Field(default_factory=list)
+    messages: List[ConversationMessage] = Field(default_factory=list)
+
+
+class ConversationList(BaseModel):
+    items: List[ConversationSummary]
+    total: int
+
+
+class FollowUpRequest(BaseModel):
+    follow_up_at: Optional[datetime] = None
+    note: Optional[str] = None
+
+
+class EscalationRequest(BaseModel):
+    reason: Optional[str] = None
+    escalate_to: Optional[str] = None
+    note: Optional[str] = None
+
+
+class FollowUpResponse(ConversationDetail):
+    pass
+
+
+class EscalationResponse(ConversationDetail):
+    pass
+
+
+class MessageIngestResponse(BaseModel):
+    conversation: ConversationDetail
+    processed_messages: int
+
+
+class ConversationAnalytics(BaseModel):
+    open_conversations: int
+    escalated_conversations: int
+    pending_follow_ups: int
+
+
+class ChannelConfigAnalytics(BaseModel):
+    channel: str
+    conversations: int
+    escalations: int
+    last_activity: Optional[datetime] = None
+
+
+class ConversationDashboardPayload(BaseModel):
+    summary: ConversationAnalytics
+    channels: List[ChannelConfigAnalytics]
+    recent_conversations: List[ConversationSummary]

--- a/app/conversations/service.py
+++ b/app/conversations/service.py
@@ -1,0 +1,211 @@
+"""High-level conversation flow orchestration."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, Optional
+
+from ..agents import schemas as agent_schemas
+from ..nlp import NlpPipeline
+from . import schemas
+from .models import EscalationDecision, FollowUpDecision, NormalizedMessage
+from .repository import ConversationRepository
+
+
+class ConversationService:
+    """Coordinates persistence, NLP enrichment and follow-up logic."""
+
+    def __init__(
+        self,
+        repository: ConversationRepository,
+        nlp_pipeline: Optional[NlpPipeline] = None,
+    ) -> None:
+        self._repository = repository
+        self._nlp = nlp_pipeline or NlpPipeline()
+
+    # ------------------------------------------------------------------
+    # Incoming message processing
+
+    def process_incoming_message(
+        self,
+        agent: agent_schemas.AgentDetail,
+        normalized: NormalizedMessage,
+        channel_config: Optional[Dict[str, Any]] = None,
+    ) -> schemas.MessageIngestResponse:
+        """Persist a message and update the conversation state."""
+
+        conversation = self._repository.get_by_external(
+            agent.id, normalized.channel, normalized.external_conversation_id
+        )
+        if not conversation:
+            conversation = self._repository.create_conversation(
+                agent.id,
+                normalized.channel,
+                normalized.external_conversation_id,
+                metadata={"channel_config": channel_config or {}},
+            )
+        participant = self._repository.get_participant(
+            conversation.id, normalized.sender_role, normalized.sender_id
+        )
+        if not participant:
+            participant = self._repository.add_participant(
+                conversation.id,
+                normalized.sender_role,
+                normalized.sender_id,
+                normalized.sender_name,
+                metadata=normalized.metadata.get("sender"),
+            )
+        nlp = self._nlp.analyse(normalized.text)
+        body = {
+            "text": normalized.text,
+            "attachments": normalized.attachments,
+            "metadata": normalized.metadata,
+        }
+        message = self._repository.add_message(
+            conversation.id,
+            participant.id if participant else None,
+            direction="inbound",
+            body=body,
+            nlp=nlp,
+            sent_at=normalized.sent_at,
+        )
+        metadata = dict(conversation.metadata)
+        metadata.setdefault("messages_ingested", 0)
+        metadata["messages_ingested"] += 1
+        decision = self._evaluate_escalation(nlp, normalized.metadata, channel_config)
+        follow_up = self._evaluate_follow_up(nlp, normalized.metadata)
+        if decision.should_escalate:
+            self._repository.mark_escalated(
+                conversation.id,
+                is_escalated=True,
+                reason=decision.reason,
+                escalate_to=decision.escalate_to,
+            )
+            metadata.setdefault("escalations", []).append(
+                {
+                    "reason": decision.reason,
+                    "escalate_to": decision.escalate_to,
+                    "at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        if follow_up.follow_up_at:
+            self._repository.set_follow_up(
+                conversation.id,
+                follow_up.follow_up_at,
+                follow_up.note,
+            )
+            metadata.setdefault("follow_ups", []).append(
+                {
+                    "scheduled_for": follow_up.follow_up_at.isoformat(),
+                    "note": follow_up.note,
+                }
+            )
+        self._repository.update_conversation_touch(
+            conversation.id,
+            last_message_at=normalized.sent_at,
+            metadata=metadata,
+        )
+        refreshed = self._repository.get_conversation(conversation.id)
+        return schemas.MessageIngestResponse(conversation=refreshed, processed_messages=1)
+
+    # ------------------------------------------------------------------
+    # Queries
+
+    def list_conversations(self, agent_id: int, limit: int = 50) -> schemas.ConversationList:
+        items = self._repository.list_conversations(agent_id, limit=limit)
+        return schemas.ConversationList(items=items, total=len(items))
+
+    def get_conversation(self, conversation_id: int) -> schemas.ConversationDetail:
+        conversation = self._repository.get_conversation(conversation_id)
+        if not conversation:
+            raise ValueError(f"Conversation {conversation_id} not found")
+        return conversation
+
+    def dashboard_snapshot(self, agent_id: int, limit: int = 10) -> schemas.ConversationDashboardPayload:
+        summary = self._repository.analytics(agent_id)
+        channels = self._repository.channel_analytics(agent_id)
+        recent = self._repository.list_conversations(agent_id, limit=limit)
+        return schemas.ConversationDashboardPayload(
+            summary=summary,
+            channels=channels,
+            recent_conversations=recent,
+        )
+
+    # ------------------------------------------------------------------
+    # Actions
+
+    def schedule_follow_up(
+        self,
+        conversation_id: int,
+        follow_up_at: Optional[datetime],
+        note: Optional[str],
+    ) -> schemas.ConversationDetail:
+        self._repository.set_follow_up(conversation_id, follow_up_at, note)
+        return self.get_conversation(conversation_id)
+
+    def escalate(
+        self,
+        conversation_id: int,
+        reason: Optional[str],
+        escalate_to: Optional[str],
+    ) -> schemas.ConversationDetail:
+        self._repository.mark_escalated(
+            conversation_id,
+            is_escalated=True,
+            reason=reason,
+            escalate_to=escalate_to,
+        )
+        return self.get_conversation(conversation_id)
+
+    def resolve_escalation(self, conversation_id: int) -> schemas.ConversationDetail:
+        self._repository.mark_escalated(
+            conversation_id,
+            is_escalated=False,
+            reason=None,
+            escalate_to=None,
+        )
+        return self.get_conversation(conversation_id)
+
+    # ------------------------------------------------------------------
+    # Helpers
+
+    def _evaluate_escalation(
+        self,
+        nlp: Dict[str, Any],
+        metadata: Dict[str, Any],
+        channel_config: Optional[Dict[str, Any]],
+    ) -> EscalationDecision:
+        escalate_flag = metadata.get("escalate") or metadata.get("escalation_required")
+        if escalate_flag:
+            return EscalationDecision(True, reason="channel_flag", escalate_to=metadata.get("target"))
+        sentiment = nlp.get("sentiment", {})
+        intent = nlp.get("intent", {})
+        min_score = (channel_config or {}).get("escalation", {}).get("sentiment_threshold", 0.75)
+        escalate_to = (channel_config or {}).get("escalation", {}).get("default_queue")
+        if intent.get("label") in {"complaint", "cancellation"}:
+            return EscalationDecision(True, reason=intent.get("label"), escalate_to=escalate_to)
+        if sentiment.get("label") == "negative" and sentiment.get("score", 0) >= min_score:
+            return EscalationDecision(True, reason="negative_sentiment", escalate_to=escalate_to)
+        return EscalationDecision(False)
+
+    def _evaluate_follow_up(
+        self, nlp: Dict[str, Any], metadata: Dict[str, Any]
+    ) -> FollowUpDecision:
+        if metadata.get("follow_up_at"):
+            return FollowUpDecision(metadata["follow_up_at"], metadata.get("follow_up_note"))
+        intent = nlp.get("intent", {})
+        if intent.get("label") in {"support_followup", "callback_request"}:
+            follow_up_at = datetime.now(timezone.utc) + timedelta(hours=24)
+            return FollowUpDecision(follow_up_at, note="Automatic follow-up scheduled")
+        entities: Iterable[Dict[str, Any]] = nlp.get("entities", [])
+        for entity in entities:
+            if entity.get("type") == "datetime" and entity.get("value"):
+                value = entity.get("value")
+                if isinstance(value, str):
+                    try:
+                        parsed = datetime.fromisoformat(value)
+                    except ValueError:
+                        continue
+                else:
+                    parsed = value
+                return FollowUpDecision(parsed, note="Entity derived follow-up")
+        return FollowUpDecision(None)

--- a/app/main.py
+++ b/app/main.py
@@ -45,7 +45,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from .rag import build_context
 from .sse_utils import sse_word_buffer
 from .app_logging import init_logging
-from .routers import admin_ingest_api, auth_api, feedback_api, agents
+from .routers import admin_ingest_api, auth_api, feedback_api, agents, conversations, webhooks
 
 try:
     from openai import OpenAI
@@ -101,6 +101,8 @@ app.include_router(admin_ingest_api.router)
 app.include_router(auth_api.router)
 app.include_router(feedback_api.router)
 app.include_router(agents.router)
+app.include_router(conversations.router)
+app.include_router(webhooks.router)
  
 # Expose Prometheus metrics
 Instrumentator().instrument(app).expose(

--- a/app/nlp.py
+++ b/app/nlp.py
@@ -1,0 +1,115 @@
+"""Lightweight NLP utilities for intent, entity and sentiment extraction."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from langdetect import detect, LangDetectException
+
+_POSITIVE = {"great", "good", "awesome", "love", "thanks", "helpful"}
+_NEGATIVE = {"bad", "terrible", "angry", "hate", "upset", "cancel", "complain"}
+
+_INTENT_PATTERNS = {
+    "complaint": re.compile(r"\bcomplain|not\s+working|angry\b", re.I),
+    "cancellation": re.compile(r"\bcancel|terminate|stop\b", re.I),
+    "support_followup": re.compile(r"follow\s*up|check\s+back", re.I),
+    "callback_request": re.compile(r"call\s+me|phone\s+me", re.I),
+}
+
+_EMAIL_PATTERN = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_AMOUNT_PATTERN = re.compile(r"\b\$?(\d+[.,]?\d*)\b")
+_DATETIME_PATTERN = re.compile(r"\b(?:tomorrow|next week|next monday|later today)\b", re.I)
+
+
+@dataclass
+class NlpPipeline:
+    """Deterministic NLP pipeline used across adapters and services."""
+
+    def analyse(self, text: str) -> Dict[str, Any]:
+        text = text or ""
+        lowered = text.lower()
+        intent_label = "unknown"
+        intent_score = 0.0
+        for label, pattern in _INTENT_PATTERNS.items():
+            if pattern.search(text):
+                intent_label = label
+                intent_score = 0.9
+                break
+        if intent_label == "unknown" and "help" in lowered:
+            intent_label = "support"
+            intent_score = 0.6
+        sentiment = self._sentiment(lowered)
+        entities = self._entities(text)
+        language = self._language(text)
+        return {
+            "intent": {"label": intent_label, "confidence": intent_score},
+            "entities": entities,
+            "sentiment": sentiment,
+            "language": language,
+        }
+
+    def _sentiment(self, lowered: str) -> Dict[str, Any]:
+        positives = sum(1 for token in _POSITIVE if token in lowered)
+        negatives = sum(1 for token in _NEGATIVE if token in lowered)
+        score = 0.0
+        label = "neutral"
+        if positives or negatives:
+            score = (positives - negatives) / max(positives + negatives, 1)
+            if score > 0:
+                label = "positive"
+            elif score < 0:
+                label = "negative"
+        if label == "negative":
+            score = min(abs(score), 1.0)
+        else:
+            score = min(score, 1.0)
+        return {"label": label, "score": abs(score)}
+
+    def _entities(self, text: str) -> List[Dict[str, Any]]:
+        entities: List[Dict[str, Any]] = []
+        for match in _EMAIL_PATTERN.finditer(text):
+            entities.append(
+                {
+                    "type": "email",
+                    "value": match.group(0),
+                    "start": match.start(),
+                    "end": match.end(),
+                }
+            )
+        for match in _AMOUNT_PATTERN.finditer(text):
+            entities.append(
+                {
+                    "type": "amount",
+                    "value": match.group(1),
+                    "start": match.start(),
+                    "end": match.end(),
+                }
+            )
+        for match in _DATETIME_PATTERN.finditer(text):
+            value = datetime.now(timezone.utc)
+            if "tomorrow" in match.group(0).lower():
+                value += timedelta(days=1)
+            elif "next week" in match.group(0).lower():
+                value += timedelta(days=7)
+            elif "next monday" in match.group(0).lower():
+                days_ahead = (0 - value.weekday() + 7) % 7 or 7
+                value += timedelta(days=days_ahead)
+            else:  # later today
+                value += timedelta(hours=4)
+            entities.append(
+                {
+                    "type": "datetime",
+                    "value": value.isoformat(),
+                    "start": match.start(),
+                    "end": match.end(),
+                }
+            )
+        return entities
+
+    def _language(self, text: str) -> Optional[str]:
+        try:
+            return detect(text) if text else None
+        except LangDetectException:
+            return None

--- a/app/routers/agents.py
+++ b/app/routers/agents.py
@@ -129,6 +129,39 @@ def list_tests(agent_id: int, role: str = Depends(require_role("viewer"))):
         return svc.list_tests(agent_id)
 
 
+
+
+@router.get("/{agent_id}/channels", response_model=schemas.ChannelConfigList)
+def list_channel_configs(agent_id: int, role: str = Depends(require_role("viewer"))) -> schemas.ChannelConfigList:
+    with _service_context() as svc:
+        configs = svc.list_channel_configs(agent_id)
+    return schemas.ChannelConfigList(items=configs, total=len(configs))
+
+
+@router.get("/{agent_id}/channels/{channel}", response_model=schemas.ChannelConfig)
+def get_channel_config(agent_id: int, channel: str, role: str = Depends(require_role("viewer"))) -> schemas.ChannelConfig:
+    with _service_context() as svc:
+        return svc.get_channel_config(agent_id, channel)
+
+
+@router.put("/{agent_id}/channels/{channel}", response_model=schemas.ChannelConfig)
+def upsert_channel_config(
+    agent_id: int,
+    channel: str,
+    payload: schemas.ChannelConfigUpdate,
+    role: str = Depends(require_role("operator")),
+) -> schemas.ChannelConfig:
+    with _service_context() as svc:
+        return svc.upsert_channel_config(agent_id, channel, payload)
+
+
+@router.delete("/{agent_id}/channels/{channel}", response_model=schemas.Message)
+def delete_channel_config(agent_id: int, channel: str, role: str = Depends(require_role("operator"))) -> schemas.Message:
+    with _service_context() as svc:
+        svc.delete_channel_config(agent_id, channel)
+    return schemas.Message(message="deleted")
+
+
 @router.post("/{agent_id}/deploy", response_model=schemas.AgentDeployResponse)
 def deploy_agent(
     agent_id: int,

--- a/app/routers/conversations.py
+++ b/app/routers/conversations.py
@@ -1,0 +1,113 @@
+"""Conversation management API routes."""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator, Tuple
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..agents.service import AgentNotFoundError, AgentService, PostgresAgentRepository
+from ..conversations.repository import PostgresConversationRepository
+from ..conversations.service import ConversationService
+from ..conversations import schemas as convo_schemas
+from ..security.auth import require_role
+
+router = APIRouter(tags=["conversations"])
+
+_DATABASE_URL = os.getenv("DATABASE_URL")
+
+
+def _get_conn() -> psycopg.Connection:
+    if not _DATABASE_URL:
+        raise HTTPException(status_code=500, detail="DATABASE_URL not configured")
+    try:
+        return psycopg.connect(_DATABASE_URL)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@contextmanager
+def _service_context() -> Iterator[Tuple[AgentService, ConversationService]]:
+    conn = _get_conn()
+    agent_repo = PostgresAgentRepository(conn)
+    convo_repo = PostgresConversationRepository(conn)
+    agent_service = AgentService(agent_repo)
+    convo_service = ConversationService(convo_repo)
+    try:
+        yield agent_service, convo_service
+        conn.commit()
+    except AgentNotFoundError as exc:
+        conn.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        conn.rollback()
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        conn.close()
+
+
+@router.get("/api/agents/{agent_id}/conversations", response_model=convo_schemas.ConversationList)
+def list_conversations(
+    agent_id: int,
+    limit: int = 20,
+    role: str = Depends(require_role("viewer")),
+) -> convo_schemas.ConversationList:
+    with _service_context() as (_, conversations):
+        return conversations.list_conversations(agent_id, limit=limit)
+
+
+@router.get("/api/agents/{agent_id}/conversations/dashboard", response_model=convo_schemas.ConversationDashboardPayload)
+def conversation_dashboard(
+    agent_id: int,
+    limit: int = 10,
+    role: str = Depends(require_role("viewer")),
+) -> convo_schemas.ConversationDashboardPayload:
+    with _service_context() as (_, conversations):
+        return conversations.dashboard_snapshot(agent_id, limit=limit)
+
+
+@router.get("/api/conversations/{conversation_id}", response_model=convo_schemas.ConversationDetail)
+def get_conversation(
+    conversation_id: int,
+    role: str = Depends(require_role("viewer")),
+) -> convo_schemas.ConversationDetail:
+    with _service_context() as (_, conversations):
+        try:
+            return conversations.get_conversation(conversation_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post("/api/conversations/{conversation_id}/follow-up", response_model=convo_schemas.FollowUpResponse)
+def schedule_follow_up(
+    conversation_id: int,
+    payload: convo_schemas.FollowUpRequest,
+    role: str = Depends(require_role("operator")),
+) -> convo_schemas.FollowUpResponse:
+    with _service_context() as (_, conversations):
+        detail = conversations.schedule_follow_up(
+            conversation_id,
+            payload.follow_up_at,
+            payload.note,
+        )
+    return convo_schemas.FollowUpResponse(**detail.model_dump())
+
+
+@router.post("/api/conversations/{conversation_id}/escalate", response_model=convo_schemas.EscalationResponse)
+def escalate_conversation(
+    conversation_id: int,
+    payload: convo_schemas.EscalationRequest,
+    resolve: bool = False,
+    role: str = Depends(require_role("operator")),
+) -> convo_schemas.EscalationResponse:
+    with _service_context() as (_, conversations):
+        if resolve:
+            detail = conversations.resolve_escalation(conversation_id)
+        else:
+            detail = conversations.escalate(conversation_id, payload.reason, payload.escalate_to)
+    return convo_schemas.EscalationResponse(**detail.model_dump())

--- a/app/routers/webhooks.py
+++ b/app/routers/webhooks.py
@@ -1,0 +1,100 @@
+"""Webhook ingestion routes for external messaging channels."""
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from typing import Iterator, Tuple
+
+import psycopg
+from fastapi import APIRouter, HTTPException, Request, Response, status
+
+from ..agents.service import (
+    AgentNotFoundError,
+    AgentService,
+    PostgresAgentRepository,
+)
+from ..channels import get_adapter
+from ..conversations.repository import PostgresConversationRepository
+from ..conversations.service import ConversationService
+from ..conversations import schemas as convo_schemas
+
+router = APIRouter(tags=["webhooks"])
+
+_DATABASE_URL = os.getenv("DATABASE_URL")
+
+
+def _get_conn() -> psycopg.Connection:
+    if not _DATABASE_URL:
+        raise HTTPException(status_code=500, detail="DATABASE_URL not configured")
+    try:
+        return psycopg.connect(_DATABASE_URL)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@contextmanager
+def _service_context() -> Iterator[Tuple[AgentService, ConversationService]]:
+    conn = _get_conn()
+    agent_repo = PostgresAgentRepository(conn)
+    convo_repo = PostgresConversationRepository(conn)
+    agent_service = AgentService(agent_repo)
+    convo_service = ConversationService(convo_repo)
+    try:
+        yield agent_service, convo_service
+        conn.commit()
+    except AgentNotFoundError as exc:
+        conn.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        conn.rollback()
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        conn.close()
+
+
+@router.post("/api/webhooks/{agent_slug}/{channel}")
+async def ingest_webhook(agent_slug: str, channel: str, request: Request) -> Response:
+    body_bytes = await request.body()
+    try:
+        payload = json.loads(body_bytes.decode("utf-8")) if body_bytes else {}
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {exc}") from exc
+
+    channel_name = channel.lower()
+    try:
+        adapter_cls = get_adapter(channel_name)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    with _service_context() as (agents, conversations):
+        agent = agents.get_agent_by_slug(agent_slug)
+        try:
+            channel_config = agents.get_channel_config(agent.id, channel_name)
+            config_dict = json.loads(channel_config.model_dump_json())
+        except AgentNotFoundError:
+            config_dict = {}
+        adapter = adapter_cls(agent_id=agent.id)
+        if not adapter.verify_signature(body_bytes, request.headers, config_dict):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid signature")
+        normalized_messages = list(adapter.parse_incoming(payload, request.headers, config_dict))
+        if not normalized_messages:
+            return Response(status_code=status.HTTP_202_ACCEPTED)
+        processed = 0
+        last_response: convo_schemas.MessageIngestResponse | None = None
+        for normalized in normalized_messages:
+            # Ensure normalized message carries correct agent/channel context
+            normalized.agent_id = agent.id
+            normalized.channel = channel_name
+            result = conversations.process_incoming_message(agent, normalized, config_dict)
+            processed += 1
+            last_response = result
+        if last_response:
+            return Response(
+                content=last_response.copy(update={"processed_messages": processed}).model_dump_json(),
+                media_type="application/json",
+            )
+        return Response(status_code=status.HTTP_202_ACCEPTED)

--- a/frontend/src/admin/Dashboard.tsx
+++ b/frontend/src/admin/Dashboard.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import { toast } from 'react-toastify';
 import { useApiFetch } from '../apiKey';
 import useAuth from '../hooks/useAuth';
 
@@ -13,77 +13,445 @@ interface JobList {
   items: Job[];
 }
 
+interface AgentSummary {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface AgentListResponse {
+  items: AgentSummary[];
+}
+
+interface ChannelConfig {
+  channel: string;
+  is_enabled: boolean;
+  webhook_secret?: string | null;
+  credentials: Record<string, unknown>;
+  settings: Record<string, unknown>;
+}
+
+interface ChannelConfigList {
+  items: ChannelConfig[];
+}
+
+interface ConversationSummary {
+  id: number;
+  agent_id: number;
+  channel: string;
+  external_conversation_id: string;
+  status: string;
+  is_escalated: boolean;
+  escalation_reason?: string | null;
+  follow_up_at?: string | null;
+  follow_up_note?: string | null;
+  last_message_at?: string | null;
+}
+
+interface ConversationAnalytics {
+  open_conversations: number;
+  escalated_conversations: number;
+  pending_follow_ups: number;
+}
+
+interface ChannelAnalytics {
+  channel: string;
+  conversations: number;
+  escalations: number;
+  last_activity?: string | null;
+}
+
+interface ConversationDashboardPayload {
+  summary: ConversationAnalytics;
+  channels: ChannelAnalytics[];
+  recent_conversations: ConversationSummary[];
+}
+
 export default function Dashboard() {
   const apiFetch = useApiFetch();
   const { roles } = useAuth();
   const canOperate = roles.includes('operator') || roles.includes('admin');
   const [jobs, setJobs] = useState<Job[]>([]);
-
-  const load = () => {
-    apiFetch('/api/admin/ingest/jobs')
-      .then((r) => r.json() as Promise<JobList>)
-      .then((d) => setJobs(d.items))
-      .catch(() => {});
-  };
+  const [agents, setAgents] = useState<AgentSummary[]>([]);
+  const [selectedAgentId, setSelectedAgentId] = useState<number | null>(null);
+  const [channelConfigs, setChannelConfigs] = useState<ChannelConfig[]>([]);
+  const [channelDrafts, setChannelDrafts] = useState<Record<string, ChannelConfig>>({});
+  const [dashboard, setDashboard] = useState<ConversationDashboardPayload | null>(null);
+  const [loadingDashboard, setLoadingDashboard] = useState(false);
+  const [newChannelName, setNewChannelName] = useState('whatsapp');
 
   useEffect(() => {
-    load();
-    const id = setInterval(load, 3000);
+    const loadJobs = () => {
+      apiFetch('/api/admin/ingest/jobs')
+        .then((r) => r.json() as Promise<JobList>)
+        .then((d) => setJobs(d.items))
+        .catch(() => {});
+    };
+    loadJobs();
+    const id = setInterval(loadJobs, 3000);
     return () => clearInterval(id);
   }, [apiFetch]);
 
-  const counts = jobs.reduce<Record<string, number>>((acc, j) => {
-    acc[j.status] = (acc[j.status] || 0) + 1;
-    return acc;
-    }, {});
+  useEffect(() => {
+    apiFetch('/api/agents')
+      .then((r) => (r.ok ? (r.json() as Promise<AgentListResponse>) : Promise.reject()))
+      .then((data) => {
+        setAgents(data.items);
+        if (!selectedAgentId && data.items.length > 0) {
+          setSelectedAgentId(data.items[0].id);
+        }
+      })
+      .catch(() => setAgents([]));
+  }, [apiFetch]);
+
+  useEffect(() => {
+    if (!selectedAgentId) return;
+    loadChannelConfigs(selectedAgentId);
+    loadConversationDashboard(selectedAgentId);
+  }, [selectedAgentId]);
+
+  const loadChannelConfigs = (agentId: number) => {
+    apiFetch(`/api/agents/${agentId}/channels`)
+      .then((r) => (r.ok ? (r.json() as Promise<ChannelConfigList>) : Promise.reject()))
+      .then((data) => {
+        setChannelConfigs(data.items);
+        const draft: Record<string, ChannelConfig> = {};
+        data.items.forEach((item) => {
+          draft[item.channel] = { ...item };
+        });
+        setChannelDrafts(draft);
+      })
+      .catch(() => {
+        setChannelConfigs([]);
+        setChannelDrafts({});
+      });
+  };
+
+  const loadConversationDashboard = (agentId: number) => {
+    setLoadingDashboard(true);
+    apiFetch(`/api/agents/${agentId}/conversations/dashboard`)
+      .then((r) => (r.ok ? (r.json() as Promise<ConversationDashboardPayload>) : Promise.reject()))
+      .then((payload) => setDashboard(payload))
+      .catch(() => setDashboard(null))
+      .finally(() => setLoadingDashboard(false));
+  };
+
+  const handleAgentChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const next = Number(event.target.value);
+    setSelectedAgentId(Number.isNaN(next) ? null : next);
+  };
+
+  const updateChannelDraft = (channel: string, updates: Partial<ChannelConfig>) => {
+    setChannelDrafts((prev) => ({
+      ...prev,
+      [channel]: { ...prev[channel], ...updates } as ChannelConfig,
+    }));
+  };
+
+  const handleChannelToggle = (channel: string) => {
+    const existing = channelDrafts[channel];
+    if (!existing) return;
+    updateChannelDraft(channel, { is_enabled: !existing.is_enabled });
+  };
+
+  const saveChannel = async (channel: string) => {
+    if (!selectedAgentId) return;
+    const draft = channelDrafts[channel];
+    if (!draft) return;
+    try {
+      await apiFetch(`/api/agents/${selectedAgentId}/channels/${channel}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          is_enabled: draft.is_enabled,
+          webhook_secret: draft.webhook_secret,
+          credentials: draft.credentials,
+          settings: draft.settings,
+        }),
+      });
+      toast.success(`Saved ${channel} settings`);
+      loadChannelConfigs(selectedAgentId);
+    } catch {
+      toast.error(`Unable to save ${channel} settings`);
+    }
+  };
+
+  const resetChannel = (channel: string) => {
+    const original = channelConfigs.find((c) => c.channel === channel);
+    if (original) {
+      setChannelDrafts((prev) => ({ ...prev, [channel]: { ...original } }));
+    }
+  };
+
+  const handleCreateChannel = (event: FormEvent) => {
+    event.preventDefault();
+    if (!selectedAgentId || !newChannelName.trim()) return;
+    const channel = newChannelName.trim().toLowerCase();
+    apiFetch(`/api/agents/${selectedAgentId}/channels/${channel}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_enabled: true, settings: {}, credentials: {} }),
+    })
+      .then(() => {
+        toast.success(`Channel ${channel} created`);
+        setNewChannelName('');
+        loadChannelConfigs(selectedAgentId);
+      })
+      .catch(() => toast.error(`Could not create ${channel}`));
+  };
+
+  const handleFollowUp = async (conversation: ConversationSummary) => {
+    if (!canOperate) return;
+    const followUpAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    try {
+      await apiFetch(`/api/conversations/${conversation.id}/follow-up`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ follow_up_at: followUpAt, note: 'Scheduled from dashboard' }),
+      });
+      toast.info('Follow-up scheduled');
+      if (selectedAgentId) loadConversationDashboard(selectedAgentId);
+    } catch {
+      toast.error('Unable to schedule follow-up');
+    }
+  };
+
+  const handleEscalation = async (conversation: ConversationSummary) => {
+    if (!canOperate) return;
+    const resolve = conversation.is_escalated;
+    const suffix = resolve ? '?resolve=true' : '';
+    try {
+      await apiFetch(`/api/conversations/${conversation.id}/escalate${suffix}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: resolve ? JSON.stringify({}) : JSON.stringify({ reason: 'manual_escalation' }),
+      });
+      toast.success(resolve ? 'Escalation resolved' : 'Conversation escalated');
+      if (selectedAgentId) loadConversationDashboard(selectedAgentId);
+    } catch {
+      toast.error('Unable to update escalation');
+    }
+  };
+
+  const conversationRows = useMemo(() => dashboard?.recent_conversations ?? [], [dashboard]);
 
   return (
-    <div>
-      <h2>Dashboard</h2>
-      <div role="status" aria-label="Job status counts">
-        {Object.entries(counts).map(([status, count]) => (
-          <div key={status}>{status}: {count}</div>
-        ))}
-      </div>
-      <table aria-label="Recent jobs">
-        <thead>
-          <tr>
-            <th>Job</th>
-            <th>Status</th>
-            <th>Created</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {jobs.slice(0, 10).map((job) => (
-            <tr key={job.id}>
-              <td><Link to={`/admin/jobs/${job.id}`}>{job.id}</Link></td>
-              <td>{job.status}</td>
-              <td>{new Date(job.created_at).toLocaleString()}</td>
-              <td>
-                <button
-                  aria-label={`Cancel job ${job.id}`}
-                  onClick={() =>
-                    apiFetch(`/api/admin/ingest/jobs/${job.id}/cancel`, { method: 'POST' }).then(load)
-                  }
-                  disabled={!canOperate}
-                >
-                  Cancel
-                </button>
-                <button
-                  aria-label={`Re-run job ${job.id}`}
-                  onClick={() =>
-                    apiFetch(`/api/admin/ingest/jobs/${job.id}/rerun`, { method: 'POST' }).then(load)
-                  }
-                  disabled={!canOperate}
-                >
-                  Re-run
-                </button>
-              </td>
-            </tr>
+    <div className="dashboard">
+      <h2>Operations Dashboard</h2>
+
+      <section aria-label="Agent selection">
+        <label htmlFor="agent-select">Agent</label>
+        <select id="agent-select" value={selectedAgentId ?? ''} onChange={handleAgentChange}>
+          <option value="" disabled>
+            Choose an agent
+          </option>
+          {agents.map((agent) => (
+            <option key={agent.id} value={agent.id}>
+              {agent.name}
+            </option>
           ))}
-        </tbody>
-      </table>
+        </select>
+      </section>
+
+      <section aria-label="Ingestion jobs">
+        <h3>Recent Ingestion Jobs</h3>
+        <table aria-label="Recent jobs">
+          <thead>
+            <tr>
+              <th>Job</th>
+              <th>Status</th>
+              <th>Created</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.slice(0, 10).map((job) => (
+              <tr key={job.id}>
+                <td>{job.id}</td>
+                <td>{job.status}</td>
+                <td>{new Date(job.created_at).toLocaleString()}</td>
+                <td>
+                  <button
+                    aria-label={`Cancel job ${job.id}`}
+                    onClick={() =>
+                      apiFetch(`/api/admin/ingest/jobs/${job.id}/cancel`, { method: 'POST' }).then(() => {
+                        setJobs((prev) => prev.filter((j) => j.id !== job.id));
+                      })
+                    }
+                    disabled={!canOperate}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    aria-label={`Re-run job ${job.id}`}
+                    onClick={() =>
+                      apiFetch(`/api/admin/ingest/jobs/${job.id}/rerun`, { method: 'POST' }).then(() => {
+                        toast.info('Job re-run requested');
+                      })
+                    }
+                    disabled={!canOperate}
+                  >
+                    Re-run
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      {selectedAgentId && (
+        <>
+          <section aria-label="Channel settings">
+            <h3>Channel Settings</h3>
+            <form onSubmit={handleCreateChannel} className="channel-create">
+              <label htmlFor="new-channel">Add channel</label>
+              <input
+                id="new-channel"
+                value={newChannelName}
+                onChange={(e) => setNewChannelName(e.target.value)}
+                placeholder="whatsapp"
+              />
+              <button type="submit" disabled={!canOperate}>
+                Add
+              </button>
+            </form>
+            {Object.keys(channelDrafts).length === 0 && <p>No channels configured yet.</p>}
+            {Object.entries(channelDrafts).map(([channel, draft]) => (
+              <div key={channel} className="channel-card">
+                <header>
+                  <h4>{channel}</h4>
+                  <span>{draft.is_enabled ? 'Enabled' : 'Disabled'}</span>
+                </header>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={draft.is_enabled}
+                    onChange={() => handleChannelToggle(channel)}
+                    disabled={!canOperate}
+                  />
+                  Enabled
+                </label>
+                <label>
+                  Webhook secret
+                  <input
+                    type="text"
+                    value={draft.webhook_secret ?? ''}
+                    onChange={(e) => updateChannelDraft(channel, { webhook_secret: e.target.value })}
+                    disabled={!canOperate}
+                  />
+                </label>
+                <div className="channel-actions">
+                  <button type="button" onClick={() => saveChannel(channel)} disabled={!canOperate}>
+                    Save
+                  </button>
+                  <button type="button" onClick={() => resetChannel(channel)} disabled={!canOperate}>
+                    Reset
+                  </button>
+                </div>
+              </div>
+            ))}
+          </section>
+
+          <section aria-label="Conversation insights">
+            <div className="conversation-header">
+              <h3>Conversation Insights</h3>
+              <button type="button" onClick={() => loadConversationDashboard(selectedAgentId)} disabled={loadingDashboard}>
+                Refresh
+              </button>
+            </div>
+            {loadingDashboard && <p>Loading conversation analytics…</p>}
+            {dashboard && (
+              <>
+                <div className="conversation-summary">
+                  <div>
+                    <strong>Open</strong>
+                    <span>{dashboard.summary.open_conversations}</span>
+                  </div>
+                  <div>
+                    <strong>Escalated</strong>
+                    <span>{dashboard.summary.escalated_conversations}</span>
+                  </div>
+                  <div>
+                    <strong>Follow-ups</strong>
+                    <span>{dashboard.summary.pending_follow_ups}</span>
+                  </div>
+                </div>
+                <table aria-label="Channel analytics">
+                  <thead>
+                    <tr>
+                      <th>Channel</th>
+                      <th>Conversations</th>
+                      <th>Escalations</th>
+                      <th>Last activity</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashboard.channels.map((chan) => (
+                      <tr key={chan.channel}>
+                        <td>{chan.channel}</td>
+                        <td>{chan.conversations}</td>
+                        <td>{chan.escalations}</td>
+                        <td>{chan.last_activity ? new Date(chan.last_activity).toLocaleString() : '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <h4>Recent conversations</h4>
+                <table aria-label="Recent conversations">
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Channel</th>
+                      <th>Status</th>
+                      <th>Escalation</th>
+                      <th>Follow-up</th>
+                      <th>Last activity</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {conversationRows.map((conversation) => (
+                      <tr key={conversation.id}>
+                        <td>{conversation.external_conversation_id}</td>
+                        <td>{conversation.channel}</td>
+                        <td>{conversation.status}</td>
+                        <td>{conversation.is_escalated ? conversation.escalation_reason || 'Escalated' : '—'}</td>
+                        <td>
+                          {conversation.follow_up_at
+                            ? new Date(conversation.follow_up_at).toLocaleString()
+                            : '—'}
+                        </td>
+                        <td>
+                          {conversation.last_message_at
+                            ? new Date(conversation.last_message_at).toLocaleString()
+                            : '—'}
+                        </td>
+                        <td>
+                          <button
+                            type="button"
+                            onClick={() => handleFollowUp(conversation)}
+                            disabled={!canOperate}
+                          >
+                            Schedule follow-up
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleEscalation(conversation)}
+                            disabled={!canOperate}
+                          >
+                            {conversation.is_escalated ? 'Resolve escalation' : 'Escalate'}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </>
+            )}
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/migrations/010_add_conversations.sql
+++ b/migrations/010_add_conversations.sql
@@ -1,0 +1,93 @@
+-- Migration: introduce channel configuration and conversation tables
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS agent_channel_configs (
+  id BIGSERIAL PRIMARY KEY,
+  agent_id BIGINT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  channel TEXT NOT NULL,
+  is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  webhook_secret TEXT,
+  credentials JSONB NOT NULL DEFAULT '{}'::jsonb,
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(agent_id, channel)
+);
+
+CREATE OR REPLACE FUNCTION set_agent_channel_configs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS agent_channel_configs_updated_at ON agent_channel_configs;
+CREATE TRIGGER agent_channel_configs_updated_at
+BEFORE UPDATE ON agent_channel_configs
+FOR EACH ROW
+EXECUTE PROCEDURE set_agent_channel_configs_updated_at();
+
+CREATE TABLE IF NOT EXISTS conversations (
+  id BIGSERIAL PRIMARY KEY,
+  agent_id BIGINT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  channel TEXT NOT NULL,
+  external_conversation_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open',
+  is_escalated BOOLEAN NOT NULL DEFAULT FALSE,
+  escalation_reason TEXT,
+  escalated_at TIMESTAMPTZ,
+  follow_up_at TIMESTAMPTZ,
+  follow_up_note TEXT,
+  last_message_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(agent_id, channel, external_conversation_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_agent ON conversations(agent_id, channel);
+CREATE INDEX IF NOT EXISTS idx_conversations_follow_up ON conversations(follow_up_at) WHERE follow_up_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_conversations_escalated ON conversations(is_escalated) WHERE is_escalated;
+
+CREATE OR REPLACE FUNCTION set_conversations_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS conversations_updated_at ON conversations;
+CREATE TRIGGER conversations_updated_at
+BEFORE UPDATE ON conversations
+FOR EACH ROW
+EXECUTE PROCEDURE set_conversations_updated_at();
+
+CREATE TABLE IF NOT EXISTS conversation_participants (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,
+  external_id TEXT,
+  display_name TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_participants_conversation ON conversation_participants(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_participants_role ON conversation_participants(conversation_id, role);
+
+CREATE TABLE IF NOT EXISTS conversation_messages (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  participant_id BIGINT REFERENCES conversation_participants(id) ON DELETE SET NULL,
+  direction TEXT NOT NULL,
+  body JSONB NOT NULL DEFAULT '{}'::jsonb,
+  nlp JSONB NOT NULL DEFAULT '{}'::jsonb,
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_messages_conversation ON conversation_messages(conversation_id, sent_at);
+
+COMMIT;

--- a/schema.sql
+++ b/schema.sql
@@ -188,3 +188,94 @@ CREATE TABLE IF NOT EXISTS agent_tests (
 
 CREATE INDEX IF NOT EXISTS idx_agent_tests_agent_id ON agent_tests(agent_id);
 CREATE INDEX IF NOT EXISTS idx_agent_tests_agent_version_id ON agent_tests(agent_version_id);
+
+-- Agent channel configuration ------------------------------------------------
+CREATE TABLE IF NOT EXISTS agent_channel_configs (
+  id BIGSERIAL PRIMARY KEY,
+  agent_id BIGINT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  channel TEXT NOT NULL,
+  is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  webhook_secret TEXT,
+  credentials JSONB NOT NULL DEFAULT '{}'::jsonb,
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(agent_id, channel)
+);
+
+CREATE OR REPLACE FUNCTION set_agent_channel_configs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS agent_channel_configs_updated_at ON agent_channel_configs;
+CREATE TRIGGER agent_channel_configs_updated_at
+BEFORE UPDATE ON agent_channel_configs
+FOR EACH ROW
+EXECUTE PROCEDURE set_agent_channel_configs_updated_at();
+
+-- Conversations --------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS conversations (
+  id BIGSERIAL PRIMARY KEY,
+  agent_id BIGINT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  channel TEXT NOT NULL,
+  external_conversation_id TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open',
+  is_escalated BOOLEAN NOT NULL DEFAULT FALSE,
+  escalation_reason TEXT,
+  escalated_at TIMESTAMPTZ,
+  follow_up_at TIMESTAMPTZ,
+  follow_up_note TEXT,
+  last_message_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(agent_id, channel, external_conversation_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_agent ON conversations(agent_id, channel);
+CREATE INDEX IF NOT EXISTS idx_conversations_follow_up ON conversations(follow_up_at) WHERE follow_up_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_conversations_escalated ON conversations(is_escalated) WHERE is_escalated;
+
+CREATE OR REPLACE FUNCTION set_conversations_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS conversations_updated_at ON conversations;
+CREATE TRIGGER conversations_updated_at
+BEFORE UPDATE ON conversations
+FOR EACH ROW
+EXECUTE PROCEDURE set_conversations_updated_at();
+
+CREATE TABLE IF NOT EXISTS conversation_participants (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,
+  external_id TEXT,
+  display_name TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_participants_conversation ON conversation_participants(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_participants_role ON conversation_participants(conversation_id, role);
+
+CREATE TABLE IF NOT EXISTS conversation_messages (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  participant_id BIGINT REFERENCES conversation_participants(id) ON DELETE SET NULL,
+  direction TEXT NOT NULL,
+  body JSONB NOT NULL DEFAULT '{}'::jsonb,
+  nlp JSONB NOT NULL DEFAULT '{}'::jsonb,
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_messages_conversation ON conversation_messages(conversation_id, sent_at);


### PR DESCRIPTION
## Summary
- add channel adapter registry with WhatsApp and Telegram implementations plus a webhook ingestion route that normalizes external messages into the conversation engine
- introduce conversation persistence, NLP enrichment, and analytics APIs to manage follow-ups and escalations across agents
- expose channel configuration CRUD endpoints and update the admin dashboard for multi-channel monitoring and scheduling tools

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df19d93190832397801854ea8e318c