### PR TITLE
Add Alembic-style migration support for multi-tenant tables

### DIFF
--- a/app/migrations/004_create_multi_tenant_tables.py
+++ b/app/migrations/004_create_multi_tenant_tables.py
@@ -1,0 +1,87 @@
+"""Create multi-tenant core tables for organizations and users."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "004_create_multi_tenant_tables"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+_UUID = postgresql.UUID(as_uuid=True)
+
+
+def upgrade() -> None:
+    """Create ``organizations`` and ``users`` tables with supporting indexes."""
+
+    op.create_table(
+        "organizations",
+        sa.Column(
+            "id",
+            _UUID,
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("subdomain", sa.String(length=255), nullable=False),
+        sa.Column(
+            "plan_type",
+            sa.String(length=64),
+            nullable=False,
+            server_default=sa.text("'free'"),
+        ),
+    )
+    op.create_index(
+        "ix_organizations_subdomain_unique",
+        "organizations",
+        ["subdomain"],
+        unique=True,
+    )
+
+    op.create_table(
+        "users",
+        sa.Column(
+            "id",
+            _UUID,
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "organization_id",
+            _UUID,
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+    )
+    op.create_index(
+        "ix_users_email_unique",
+        "users",
+        ["email"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_users_organization_id",
+        "users",
+        ["organization_id"],
+    )
+
+
+def downgrade() -> None:
+    """Remove ``users`` and ``organizations`` tables and related indexes."""
+
+    op.drop_index("ix_users_organization_id", table_name="users")
+    op.drop_index("ix_users_email_unique", table_name="users")
+    op.drop_table("users")
+
+    op.drop_index("ix_organizations_subdomain_unique", table_name="organizations")
+    op.drop_table("organizations")

--- a/app/migrations/__init__.py
+++ b/app/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Application database migrations executed via ``ensure_schema``."""

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,5 +1,7 @@
 # Locked dependencies for reproducible installs
 psycopg[binary]==3.1.19
+SQLAlchemy==2.0.32
+alembic==1.13.2
 pgvector==0.2.5
 pypdf==4.2.0
 python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 psycopg[binary]>=3.1
+SQLAlchemy>=2.0
+alembic>=1.12
 pgvector>=0.2.5
 pypdf>=4.2
 python-dotenv>=1.0

--- a/tests/test_multi_tenant_migration.py
+++ b/tests/test_multi_tenant_migration.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pathlib
+
+import psycopg
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import make_url
+
+from app.ingestion.service import SCHEMA_PATH, ensure_schema
+
+
+def _schema_without_vector(tmp_path: pathlib.Path) -> pathlib.Path:
+    schema_text = SCHEMA_PATH.read_text(encoding="utf-8")
+    schema_text = schema_text.replace(
+        "CREATE EXTENSION IF NOT EXISTS vector;",
+        "-- vector extension skipped in tests",
+    )
+    schema_text = schema_text.replace("VECTOR(384)", "DOUBLE PRECISION[]")
+    path = tmp_path / "schema.sql"
+    path.write_text(schema_text, encoding="utf-8")
+    return path
+
+
+@pytest.mark.integration
+def test_multi_tenant_migration_creates_tables(tmp_path: pathlib.Path) -> None:
+    testing_postgresql = pytest.importorskip("testing.postgresql")
+    try:
+        pg = testing_postgresql.Postgresql()
+    except RuntimeError as exc:
+        pytest.skip(f"testing.postgresql is unavailable: {exc}")
+
+    schema_path = _schema_without_vector(tmp_path)
+
+    try:
+        with psycopg.connect(pg.url()) as conn:
+            ensure_schema(conn, schema_sql_path=schema_path)
+            ensure_schema(conn, schema_sql_path=schema_path)
+
+        engine = sa.create_engine(make_url(pg.url()).set(drivername="postgresql+psycopg"))
+        try:
+            with engine.connect() as connection:
+                inspector = sa.inspect(connection)
+                tables = inspector.get_table_names()
+                assert "organizations" in tables
+                assert "users" in tables
+
+                org_columns = {col["name"] for col in inspector.get_columns("organizations")}
+                assert {"id", "name", "subdomain", "plan_type"}.issubset(org_columns)
+
+                user_columns = {col["name"] for col in inspector.get_columns("users")}
+                assert {"id", "organization_id", "email", "password_hash", "name"}.issubset(
+                    user_columns
+                )
+
+                org_indexes = inspector.get_indexes("organizations")
+                assert any(
+                    idx["name"] == "ix_organizations_subdomain_unique"
+                    and idx.get("unique")
+                    and idx.get("column_names") == ["subdomain"]
+                    for idx in org_indexes
+                )
+
+                user_indexes = inspector.get_indexes("users")
+                assert any(
+                    idx["name"] == "ix_users_email_unique"
+                    and idx.get("unique")
+                    and idx.get("column_names") == ["email"]
+                    for idx in user_indexes
+                )
+                assert any(
+                    idx["name"] == "ix_users_organization_id"
+                    and idx.get("column_names") == ["organization_id"]
+                    for idx in user_indexes
+                )
+
+                fks = inspector.get_foreign_keys("users")
+                assert any(fk["referred_table"] == "organizations" for fk in fks)
+        finally:
+            engine.dispose()
+
+        with psycopg.connect(pg.url()) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id FROM app_python_migrations WHERE id = %s",
+                    ("004_create_multi_tenant_tables",),
+                )
+                assert cur.fetchone()
+    finally:
+        pg.stop()


### PR DESCRIPTION
## Summary
- extend `ensure_schema` with a lightweight Alembic-style runner that tracks executed Python migrations
- add the 004 multi-tenant migration defining `organizations` and `users` tables with required indexes
- include SQLAlchemy/Alembic dependencies and an integration test that validates the new tables and metadata against a temporary Postgres instance

## Testing
- pytest tests/test_multi_tenant_migration.py

------
https://chatgpt.com/codex/tasks/task_e_68dfccc7896883239803dc24fdf5014c