### PR TITLE
Add SQLAlchemy tenant models and tests

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,27 @@
+"""SQLAlchemy declarative base and tenant-facing models.
+
+This package hosts the SQLAlchemy models used across the backend.  It exposes a
+single declarative ``Base`` class that other modules can import when creating
+tables or writing migrations in Python.  Individual models live in dedicated
+modules within this package.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all SQLAlchemy declarative models."""
+
+
+# Re-export core tenant models for convenience so callers can import them via
+# ``from app.models import Organization`` instead of touching private modules.
+from .tenant import Organization, User
+
+
+__all__ = [
+    "Base",
+    "Organization",
+    "User",
+]

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -1,0 +1,57 @@
+"""Helpers for configuring SQLAlchemy engine and session factories."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from . import Base
+
+
+def get_engine(database_url: str | None = None, **kwargs: object) -> Engine:
+    """Create a SQLAlchemy engine.
+
+    Args:
+        database_url: Optional database URL. When ``None`` the ``DATABASE_URL``
+            environment variable is used.
+        **kwargs: Additional keyword arguments forwarded to
+            :func:`sqlalchemy.create_engine`.
+
+    Returns:
+        Configured SQLAlchemy :class:`~sqlalchemy.engine.Engine` instance.
+    """
+
+    url = database_url or os.getenv("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL is not configured.")
+    return create_engine(url, **kwargs)
+
+
+def get_sessionmaker(database_url: str | None = None, **kwargs: object) -> sessionmaker[Session]:
+    """Return a session factory bound to the configured engine."""
+
+    engine = get_engine(database_url=database_url, **kwargs)
+    return sessionmaker(bind=engine, expire_on_commit=False, future=True)
+
+
+@contextmanager
+def session_scope(database_url: str | None = None, **kwargs: object) -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+
+    factory = get_sessionmaker(database_url=database_url, **kwargs)
+    session = factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+__all__ = ["Base", "get_engine", "get_sessionmaker", "session_scope"]

--- a/app/models/tenant.py
+++ b/app/models/tenant.py
@@ -1,0 +1,96 @@
+"""Tenant-related SQLAlchemy models.
+
+The models defined here represent the core multi-tenant entities used by the
+platform: organizations and their users.  They mirror the DDL maintained in the
+migrations (see ``app/migrations/004_create_multi_tenant_tables.py``) to ensure
+consistency between ORM usage and raw SQL migrations.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+from sqlalchemy import ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+
+class Organization(Base):
+    """Represents a tenant organization in the platform.
+
+    Attributes:
+        id: Primary key generated via ``gen_random_uuid`` in Postgres.
+        name: Display name of the organization.
+        subdomain: Unique subdomain used for tenant isolation.
+        plan_type: Current subscription tier for the organization.
+        users: Collection of users that belong to this organization.
+    """
+
+    __tablename__ = "organizations"
+    __table_args__ = (
+        Index("ix_organizations_subdomain_unique", "subdomain", unique=True),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    name: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    subdomain: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    plan_type: Mapped[str] = mapped_column(
+        String(length=64),
+        nullable=False,
+        default="free",
+        server_default=text("'free'"),
+    )
+
+    users: Mapped[List["User"]] = relationship(
+        back_populates="organization",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class User(Base):
+    """Represents a user that belongs to an organization.
+
+    Attributes:
+        id: Primary key generated via ``gen_random_uuid`` in Postgres.
+        organization_id: Foreign key that links to the owning organization.
+        email: Unique e-mail address used for authentication.
+        password_hash: Secure hash of the user's password.
+        name: Friendly name shown in the UI and logs.
+        organization: Relationship back to :class:`Organization`.
+    """
+
+    __tablename__ = "users"
+    __table_args__ = (
+        Index("ix_users_email_unique", "email", unique=True),
+        Index("ix_users_organization_id", "organization_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    email: Mapped[str] = mapped_column(String(length=320), nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    name: Mapped[str] = mapped_column(String(length=255), nullable=False)
+
+    organization: Mapped[Organization] = relationship(
+        back_populates="users",
+        lazy="joined",
+    )
+
+
+__all__ = ["Organization", "User"]

--- a/tests/test_tenant_models.py
+++ b/tests/test_tenant_models.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+from sqlalchemy import create_engine  # type: ignore  # noqa: E402
+from sqlalchemy.exc import IntegrityError  # type: ignore  # noqa: E402
+from sqlalchemy.orm import Session, sessionmaker  # type: ignore  # noqa: E402
+
+from app.models import Base, Organization, User
+
+
+@pytest.fixture
+def engine():
+    return create_engine("sqlite+pysqlite:///:memory:", future=True)
+
+
+@pytest.fixture
+def session(engine):
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    with factory() as session:
+        yield session
+        session.rollback()
+    Base.metadata.drop_all(engine)
+
+
+def test_can_persist_organization_and_user(session: Session) -> None:
+    organization = Organization(
+        id=uuid.uuid4(),
+        name="Acme Inc.",
+        subdomain="acme",
+    )
+    session.add(organization)
+    session.flush()
+
+    user = User(
+        id=uuid.uuid4(),
+        organization_id=organization.id,
+        email="owner@acme.com",
+        password_hash="hashed",
+        name="Owner",
+    )
+    session.add(user)
+    session.flush()
+
+    assert organization.plan_type == "free"
+    assert user.organization_id == organization.id
+    assert user.organization is organization
+    assert organization.users == [user]
+
+
+def test_unique_subdomain_constraint(session: Session) -> None:
+    session.add(
+        Organization(
+            id=uuid.uuid4(),
+            name="First",
+            subdomain="tenant",
+        )
+    )
+    session.commit()
+
+    with pytest.raises(IntegrityError):
+        session.add(
+            Organization(
+                id=uuid.uuid4(),
+                name="Second",
+                subdomain="tenant",
+            )
+        )
+        session.commit()
+    session.rollback()
+
+
+def test_unique_email_constraint(session: Session) -> None:
+    org = Organization(id=uuid.uuid4(), name="Org", subdomain="org")
+    session.add(org)
+    session.flush()
+
+    session.add(
+        User(
+            id=uuid.uuid4(),
+            organization_id=org.id,
+            email="member@org.com",
+            password_hash="hash",
+            name="Member",
+        )
+    )
+    session.commit()
+
+    with pytest.raises(IntegrityError):
+        session.add(
+            User(
+                id=uuid.uuid4(),
+                organization_id=org.id,
+                email="member@org.com",
+                password_hash="hash2",
+                name="Member Two",
+            )
+        )
+        session.commit()
+    session.rollback()


### PR DESCRIPTION
## Summary
- create the new app.models package with a declarative base
- implement Organization and User SQLAlchemy models plus a session helper layer
- add unit tests that exercise persistence and uniqueness constraints for the tenant models

## Testing
- pytest tests/test_tenant_models.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd0cb8d5c8323ae5f276dea0cf51e