### PR TITLE
Add tenant token authentication utilities

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,154 @@
+"""Utilities for tenant-aware authentication."""
+
+from __future__ import annotations
+
+import os
+from typing import TypedDict, cast
+
+import jwt
+from fastapi import HTTPException, Request, status
+from jwt import ExpiredSignatureError, InvalidTokenError
+
+__all__ = [
+    "TenantTokenPayload",
+    "TenantTokenConfigurationError",
+    "TenantTokenValidationError",
+    "decode_tenant_token",
+    "get_tenant_context",
+]
+
+
+class TenantTokenConfigurationError(RuntimeError):
+    """Raised when tenant token configuration is invalid."""
+
+
+class TenantTokenValidationError(ValueError):
+    """Raised when the provided tenant token cannot be validated."""
+
+
+class _TenantTokenRequiredClaims(TypedDict):
+    tenant_id: str
+    user_id: str
+
+
+class TenantTokenPayload(_TenantTokenRequiredClaims, total=False):
+    """Decoded JWT payload for tenant-scoped authentication."""
+
+    aud: str | list[str]
+    email: str
+    exp: int
+    iat: int
+    iss: str
+    name: str
+    roles: list[str]
+    scope: str
+
+
+def _get_env(name: str, *, required: bool = True, default: str | None = None) -> str:
+    """Fetch an environment variable with optional requirement enforcement.
+
+    Args:
+        name: Name of the environment variable to read.
+        required: Whether to raise when the variable is missing or empty.
+        default: Value to use when ``required`` is ``False`` and the variable is
+            undefined.
+
+    Returns:
+        str: Stripped environment variable value or provided default.
+
+    Raises:
+        TenantTokenConfigurationError: If ``required`` is ``True`` and the
+            variable is missing or blank.
+    """
+
+    value = os.getenv(name, default)
+    if required and (value is None or not value.strip()):
+        raise TenantTokenConfigurationError(
+            f"Environment variable '{name}' must be set for tenant token validation.",
+        )
+    if value is None:
+        return ""
+    return value.strip()
+
+
+def decode_tenant_token(token: str) -> TenantTokenPayload:
+    """Decode and validate a tenant access token.
+
+    Args:
+        token: Encoded JWT token string from the ``Authorization`` header.
+
+    Returns:
+        TenantTokenPayload: Parsed payload containing tenant and user identifiers.
+
+    Raises:
+        TenantTokenConfigurationError: If mandatory environment configuration is missing.
+        TenantTokenValidationError: If token signature, claims, or expiry are invalid.
+    """
+
+    secret_key = _get_env("TENANT_TOKEN_SECRET")
+    audience = _get_env("TENANT_TOKEN_AUDIENCE")
+    issuer = _get_env("TENANT_TOKEN_ISSUER")
+    algorithm = _get_env("TENANT_TOKEN_ALGORITHM", required=False, default="HS256")
+
+    try:
+        payload = jwt.decode(
+            token,
+            secret_key,
+            algorithms=[algorithm],
+            audience=audience,
+            issuer=issuer,
+            options={"require": ["exp", "aud", "iss"]},
+        )
+    except ExpiredSignatureError as exc:
+        raise TenantTokenValidationError("Tenant token has expired.") from exc
+    except InvalidTokenError as exc:
+        raise TenantTokenValidationError("Tenant token is invalid.") from exc
+
+    if "tenant_id" not in payload or "user_id" not in payload:
+        raise TenantTokenValidationError(
+            "Tenant token payload must include 'tenant_id' and 'user_id'.",
+        )
+
+    return cast(TenantTokenPayload, payload)
+
+
+async def get_tenant_context(request: Request) -> TenantTokenPayload:
+    """Extract tenant context from the ``Authorization`` header.
+
+    Args:
+        request: Incoming request whose headers may contain a bearer token.
+
+    Returns:
+        TenantTokenPayload: Validated tenant token payload for downstream dependencies.
+
+    Raises:
+        HTTPException: With status ``401`` when the header is missing or invalid,
+            or ``500`` if the tenant token configuration is incorrect.
+    """
+
+    authorization = request.headers.get("Authorization")
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header.",
+        )
+
+    scheme, _, credentials = authorization.partition(" ")
+    if not credentials or scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authorization header must use Bearer scheme.",
+        )
+
+    try:
+        return decode_tenant_token(credentials)
+    except TenantTokenConfigurationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        ) from exc
+    except TenantTokenValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+        ) from exc

--- a/requirements.lock
+++ b/requirements.lock
@@ -16,6 +16,7 @@ python-multipart==0.0.20
 pytest==8.3.2
 slowapi==0.1.9
 langdetect==1.0.9
+PyJWT==2.9.0
 pytesseract==0.3.13
 pdf2image==1.17.0
 Pillow==10.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ python-multipart>=0.0.7
 pytest>=8.0
 slowapi>=0.1.8
 langdetect>=1.0.9
+PyJWT>=2.8.0
 pytesseract
 pdf2image
 Pillow

--- a/tests/test_core_auth.py
+++ b/tests/test_core_auth.py
@@ -1,0 +1,154 @@
+"""Tests for tenant-aware authentication helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.auth import (
+    TenantTokenConfigurationError,
+    TenantTokenPayload,
+    TenantTokenValidationError,
+    decode_tenant_token,
+    get_tenant_context,
+)
+
+
+@pytest.fixture()
+def token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set required environment variables for tenant token decoding."""
+
+    monkeypatch.setenv("TENANT_TOKEN_SECRET", "secret-key")
+    monkeypatch.setenv("TENANT_TOKEN_AUDIENCE", "chatvolt")
+    monkeypatch.setenv("TENANT_TOKEN_ISSUER", "auth.chatvolt")
+    monkeypatch.setenv("TENANT_TOKEN_ALGORITHM", "HS256")
+
+
+def _issue_token(
+    *,
+    secret: str = "secret-key",
+    audience: str = "chatvolt",
+    issuer: str = "auth.chatvolt",
+    tenant_id: str | None = "tenant-123",
+    user_id: str | None = "user-456",
+    **extra_claims: str | list[str] | int,
+) -> str:
+    """Generate a signed JWT for testing purposes."""
+
+    payload: dict[str, object] = {
+        "aud": audience,
+        "iss": issuer,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+    if tenant_id is not None:
+        payload["tenant_id"] = tenant_id
+    if user_id is not None:
+        payload["user_id"] = user_id
+    payload.update(extra_claims)
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def test_decode_tenant_token_success(token_env: None) -> None:
+    """A valid token returns the decoded payload."""
+
+    token = _issue_token(roles=["admin"])
+
+    payload = decode_tenant_token(token)
+
+    assert payload["tenant_id"] == "tenant-123"
+    assert payload["user_id"] == "user-456"
+    assert payload["roles"] == ["admin"]
+
+
+def test_decode_tenant_token_missing_required_claims(token_env: None) -> None:
+    """Tokens missing tenant or user identifiers are rejected."""
+
+    token = _issue_token(user_id=None)
+
+    with pytest.raises(TenantTokenValidationError):
+        decode_tenant_token(token)
+
+
+def test_decode_tenant_token_configuration_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing configuration raises a configuration error."""
+
+    monkeypatch.delenv("TENANT_TOKEN_SECRET", raising=False)
+    monkeypatch.delenv("TENANT_TOKEN_AUDIENCE", raising=False)
+    monkeypatch.delenv("TENANT_TOKEN_ISSUER", raising=False)
+
+    with pytest.raises(TenantTokenConfigurationError):
+        decode_tenant_token("token")
+
+
+def _create_test_client() -> TestClient:
+    """Create a FastAPI application wired with the tenant dependency."""
+
+    app = FastAPI()
+
+    @app.get("/tenant")
+    async def read_tenant(payload: TenantTokenPayload = Depends(get_tenant_context)) -> TenantTokenPayload:
+        return payload
+
+    return TestClient(app)
+
+
+def test_get_tenant_context_success(token_env: None) -> None:
+    """Dependency returns payload when a valid bearer token is supplied."""
+
+    client = _create_test_client()
+    token = _issue_token()
+
+    response = client.get("/tenant", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json()["tenant_id"] == "tenant-123"
+
+
+def test_get_tenant_context_missing_header(token_env: None) -> None:
+    """Missing Authorization header yields 401 Unauthorized."""
+
+    client = _create_test_client()
+
+    response = client.get("/tenant")
+
+    assert response.status_code == 401
+
+
+def test_get_tenant_context_invalid_scheme(token_env: None) -> None:
+    """Non-bearer Authorization scheme is rejected."""
+
+    client = _create_test_client()
+    token = _issue_token()
+
+    response = client.get("/tenant", headers={"Authorization": f"Token {token}"})
+
+    assert response.status_code == 401
+
+
+def test_get_tenant_context_invalid_signature(token_env: None) -> None:
+    """An invalid token signature maps to 401 Unauthorized."""
+
+    client = _create_test_client()
+    token = _issue_token(secret="another-secret")
+
+    response = client.get("/tenant", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 401
+
+
+def test_get_tenant_context_configuration_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configuration issues propagate as HTTP 500 errors."""
+
+    monkeypatch.delenv("TENANT_TOKEN_SECRET", raising=False)
+    monkeypatch.setenv("TENANT_TOKEN_AUDIENCE", "chatvolt")
+    monkeypatch.setenv("TENANT_TOKEN_ISSUER", "auth.chatvolt")
+
+    client = _create_test_client()
+
+    response = client.get("/tenant", headers={"Authorization": "Bearer token"})
+
+    assert response.status_code == 500


### PR DESCRIPTION
## Summary
- add tenant token decoding helpers and HTTP dependency for tenant-aware requests
- validate tenant JWTs against configured audience, issuer, and expiry using PyJWT
- cover the new authentication flow with dedicated unit tests and add the PyJWT dependency

## Testing
- pytest tests/test_core_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe05674c483239019774c0d3854d5