### PR TITLE
Add tenant-aware request middleware

### DIFF
--- a/app/core/tenant_context.py
+++ b/app/core/tenant_context.py
@@ -1,0 +1,77 @@
+"""Runtime helpers for storing tenant-aware request context.
+
+This module exposes a small API around a :class:`contextvars.ContextVar`
+that keeps track of the current tenant during a request lifecycle. The
+``TenantContextMiddleware`` populates the context by calling
+``set_tenant_context`` and obtains a token that must be passed back to
+``reset_tenant_context`` once the response has been sent. Other layers (for
+example repositories or background services) can call
+``get_current_tenant_id`` to discover which tenant is being served without
+needing access to the original HTTP request object.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from typing import TypedDict
+
+__all__ = [
+    "TenantRuntimeContext",
+    "get_current_tenant_id",
+    "reset_tenant_context",
+    "set_tenant_context",
+]
+
+
+class TenantRuntimeContext(TypedDict):
+    """Values stored in the tenant context during a request."""
+
+    tenant_id: str
+    user_id: str
+
+
+_tenant_context: ContextVar[TenantRuntimeContext | None] = ContextVar(
+    "tenant_runtime_context", default=None
+)
+
+
+def set_tenant_context(tenant_id: str, user_id: str) -> Token[TenantRuntimeContext | None]:
+    """Persist the tenant metadata in the request-scoped context variable.
+
+    Args:
+        tenant_id: Identifier of the tenant extracted from the JWT payload.
+        user_id: Identifier of the authenticated user.
+
+    Returns:
+        ``Token`` returned by :meth:`contextvars.ContextVar.set`. Callers must
+        later pass this token to :func:`reset_tenant_context` to restore the
+        previous value once the response has been sent (the middleware performs
+        this automatically).
+    """
+
+    return _tenant_context.set({"tenant_id": tenant_id, "user_id": user_id})
+
+
+def reset_tenant_context(token: Token[TenantRuntimeContext | None]) -> None:
+    """Restore the tenant context to the state prior to ``set_tenant_context``.
+
+    Args:
+        token: Handle returned by :func:`set_tenant_context`.
+    """
+
+    _tenant_context.reset(token)
+
+
+def get_current_tenant_id() -> str | None:
+    """Return the tenant identifier for the current execution context.
+
+    The function returns ``None`` when the middleware has not populated the
+    context, allowing downstream consumers to handle unauthenticated flows in
+    a controlled fashion.
+    """
+
+    context = _tenant_context.get()
+    if context is None:
+        return None
+    return context["tenant_id"]
+

--- a/app/core/tenant_middleware.py
+++ b/app/core/tenant_middleware.py
@@ -1,0 +1,104 @@
+"""Middleware responsible for wiring tenant context into each request."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Callable, Awaitable
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy import Engine, text
+from sqlalchemy.engine import Connection
+from sqlalchemy.exc import SQLAlchemyError
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from app.models.session import get_engine
+
+from .auth import TenantTokenPayload, get_tenant_context
+from .tenant_context import reset_tenant_context, set_tenant_context
+
+__all__ = ["TenantContextMiddleware"]
+
+logger = logging.getLogger(__name__)
+
+
+class TenantContextMiddleware(BaseHTTPMiddleware):
+    """Populate request state and database session with tenant metadata."""
+
+    def __init__(self, app: ASGIApp, *, engine: Engine | None = None) -> None:
+        super().__init__(app)
+        self._engine = engine
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:  # type: ignore[override]
+        if not self._is_configured():
+            return await call_next(request)
+
+        payload = await get_tenant_context(request)
+        request.state.tenant_id = payload["tenant_id"]
+        request.state.user_id = payload["user_id"]
+
+        context_token = set_tenant_context(payload["tenant_id"], payload["user_id"])
+        connection: Connection | None = None
+
+        try:
+            connection = self._prepare_connection(payload)
+        except SQLAlchemyError as exc:  # pragma: no cover - defensive, engine optional
+            reset_tenant_context(context_token)
+            logger.exception("Failed to configure tenant context for request.")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Unable to configure tenant context.",
+            ) from exc
+
+        try:
+            return await call_next(request)
+        finally:
+            if connection is not None:
+                try:
+                    connection.execute(text("RESET app.tenant_id"))
+                except SQLAlchemyError:  # pragma: no cover - best effort cleanup
+                    logger.exception("Failed to reset tenant id configuration.")
+                finally:
+                    connection.close()
+            reset_tenant_context(context_token)
+
+    def _prepare_connection(self, payload: TenantTokenPayload) -> Connection | None:
+        engine = self._resolve_engine()
+        if engine is None:
+            return None
+
+        connection = engine.connect()
+        try:
+            connection.execute(
+                text("SELECT set_config('app.tenant_id', :tenant_id, true)"),
+                {"tenant_id": payload["tenant_id"]},
+            )
+        except SQLAlchemyError:
+            connection.close()
+            raise
+        return connection
+
+    def _resolve_engine(self) -> Engine | None:
+        if self._engine is not None:
+            return self._engine
+
+        try:
+            self._engine = get_engine()
+        except RuntimeError:
+            logger.debug("Database engine not configured; skipping tenant set_config.")
+            return None
+        return self._engine
+
+    @staticmethod
+    def _is_configured() -> bool:
+        required = (
+            os.getenv("TENANT_TOKEN_SECRET"),
+            os.getenv("TENANT_TOKEN_AUDIENCE"),
+            os.getenv("TENANT_TOKEN_ISSUER"),
+        )
+        return all(required)
+

--- a/app/main.py
+++ b/app/main.py
@@ -46,6 +46,7 @@ from .rag import build_context
 from .sse_utils import sse_word_buffer
 from .app_logging import init_logging
 from .routers import admin_ingest_api, auth_api, feedback_api, agents, conversations, webhooks
+from .core.tenant_middleware import TenantContextMiddleware
 
 try:
     from openai import OpenAI
@@ -85,6 +86,7 @@ init_logging(app)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)
+app.add_middleware(TenantContextMiddleware)
 # Optional CORS for admin UI
 admin_ui_origins = os.getenv("ADMIN_UI_ORIGINS")
 if admin_ui_origins:

--- a/tests/test_tenant_middleware.py
+++ b/tests/test_tenant_middleware.py
@@ -1,0 +1,118 @@
+"""Integration tests for the tenant context middleware."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")
+from app.core.tenant_context import get_current_tenant_id
+from app.core.tenant_middleware import TenantContextMiddleware
+
+
+@pytest.fixture(autouse=True)
+def tenant_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the middleware is enabled by configuring token settings."""
+
+    monkeypatch.setenv("TENANT_TOKEN_SECRET", "secret-key")
+    monkeypatch.setenv("TENANT_TOKEN_AUDIENCE", "chatvolt")
+    monkeypatch.setenv("TENANT_TOKEN_ISSUER", "auth.chatvolt")
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _issue_token(*, tenant_id: str = "tenant-1", user_id: str = "user-1") -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    payload: dict[str, Any] = {
+        "tenant_id": tenant_id,
+        "user_id": user_id,
+        "aud": "chatvolt",
+        "iss": "auth.chatvolt",
+        "exp": int(time.time()) + 300,
+    }
+    header_segment = _b64encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_segment = _b64encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{header_segment}.{payload_segment}".encode()
+    signature = hmac.new(b"secret-key", signing_input, hashlib.sha256).digest()
+    signature_segment = _b64encode(signature)
+    return ".".join([header_segment, payload_segment, signature_segment])
+
+
+@dataclass
+class DummyConnection:
+    statements: list[str]
+
+    def execute(self, statement: Any, params: dict[str, Any] | None = None) -> None:  # pragma: no cover - trivial
+        self.statements.append(str(statement))
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        self.statements.append("CLOSE")
+
+
+@dataclass
+class DummyEngine:
+    connection: DummyConnection
+
+    def connect(self) -> DummyConnection:
+        return self.connection
+
+
+def _create_app(engine: DummyEngine) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(TenantContextMiddleware, engine=engine)  # type: ignore[arg-type]
+
+    @app.get("/context")
+    async def read_context(request: Request) -> JSONResponse:
+        return JSONResponse(
+            {
+                "tenant_id": request.state.tenant_id,
+                "user_id": request.state.user_id,
+                "context_tenant": get_current_tenant_id(),
+            }
+        )
+
+    return app
+
+
+def test_middleware_sets_state_and_context() -> None:
+    connection = DummyConnection(statements=[])
+    engine = DummyEngine(connection=connection)
+    app = _create_app(engine)
+
+    token = _issue_token()
+    client = TestClient(app)
+    response = client.get("/context", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "tenant_id": "tenant-1",
+        "user_id": "user-1",
+        "context_tenant": "tenant-1",
+    }
+    assert "set_config" in connection.statements[0]
+    assert connection.statements[-2] == "RESET app.tenant_id"
+    assert connection.statements[-1] == "CLOSE"
+    assert get_current_tenant_id() is None
+
+
+def test_missing_token_returns_unauthorized() -> None:
+    connection = DummyConnection(statements=[])
+    engine = DummyEngine(connection=connection)
+    app = _create_app(engine)
+
+    client = TestClient(app)
+    response = client.get("/context")
+
+    assert response.status_code == 401
+    assert connection.statements == []


### PR DESCRIPTION
## Summary
- add a TenantContextMiddleware that extracts tenant information, stores it in request state/contextvars, and configures the database session
- provide helper utilities for reading and resetting tenant context from other layers
- register the middleware in the FastAPI app and add coverage for the new behaviour

## Testing
- pytest tests/test_tenant_middleware.py (skipped: requires SQLAlchemy)


------
https://chatgpt.com/codex/tasks/task_e_68dfe1e675488323a4c5f119129fad07