### PR TITLE
chore: scrub secrets from env configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,18 +3,18 @@
 # ---------------------------------------------------------------------------
 # API keys for admin ingestion endpoints
 # Default development values are admin/oper/view
-ADMIN_API_KEY=admin
-OP_API_KEY=oper
-VIEW_API_KEY=view
+ADMIN_API_KEY=
+OP_API_KEY=
+VIEW_API_KEY=
 
 # ---------------------------------------------------------------------------
 # Database
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+DATABASE_URL=postgresql://<db_user>:<db_password>@<db_host>:5432/<db_name>
 PGHOST=db
 PGPORT=5432
 PGDATABASE=pdfkb
 PGUSER=pdfkb
-PGPASSWORD=pdfkb
+PGPASSWORD=
 
 # ---------------------------------------------------------------------------
 # Logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
       - .env
     environment:
       # Initialize database and user on first run, matching values from .env
-      POSTGRES_USER: ${PGUSER:-pdfkb}
-      POSTGRES_PASSWORD: ${PGPASSWORD:-pdfkb}
-      POSTGRES_DB: ${PGDATABASE:-pdfkb}
+      POSTGRES_USER: ${PGUSER}
+      POSTGRES_PASSWORD: ${PGPASSWORD}
+      POSTGRES_DB: ${PGDATABASE}
     ports:
       - "5432:5432"
     expose:


### PR DESCRIPTION
## Summary
- remove default API key and database password values from `.env.example`
- require `docker-compose` to read database credentials exclusively from the environment file

## Testing
- pytest -q *(fails: relies on dummy cursor without `fetchall` and tenant middleware token setup in tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ea6feea88323ad3df5c3733cc5d4)