### PR TITLE
Fix AgentService slug lookup and add regression test

### DIFF
--- a/tests/test_agents_service.py
+++ b/tests/test_agents_service.py
@@ -1,0 +1,29 @@
+"""Regression tests for :mod:`app.agents.service`."""
+
+from app.agents import schemas
+from app.agents.service import AgentService, InMemoryAgentRepository
+
+
+def test_get_agent_by_slug_with_inmemory_repository():
+    repository = InMemoryAgentRepository()
+    service = AgentService(repository)
+
+    payload = schemas.AgentCreate(
+        name="Support Bot",
+        description="Helps customers with common issues",
+        provider="openai",
+        model="gpt-4o-mini",
+        persona={"type": "support"},
+        response_parameters={"temperature": 0.2},
+    )
+
+    created = service.create_agent(payload)
+
+    fetched = service.get_agent_by_slug(created.slug)
+
+    assert fetched.id == created.id
+    assert fetched.slug == created.slug
+    assert fetched.name == payload.name
+    assert fetched.versions, "Expected versions to be included by default"
+    assert fetched.latest_version is not None
+    assert fetched.tests == []


### PR DESCRIPTION
## Summary
- remove the duplicate `get_agent_by_slug` implementation from `AgentService` and forward include flags to the repository
- keep the Postgres repository query for slug lookups and implement in-memory slug lookups without relying on database cursors
- add a regression test that exercises `AgentService.get_agent_by_slug` when backed by the in-memory repository

## Testing
- pytest tests/test_agents_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ee35822c8323b408c0934e548554)