### PR TITLE
Implement tenant account management API and middleware refinements

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -86,12 +86,12 @@ Most administrative routers protect endpoints with the `require_role` dependency
 
 #### GET `/api/auth/roles`
 
-- **Auth:** `X-API-Key` with `viewer` role or higher.【F:app/routers/auth_api.py†L1-L10】【F:app/security/auth.py†L50-L90】
-- **Responses:** 200 with `{ "roles": ["<caller-role>"] }`.
+- **Auth:** Cabeçalho `Authorization: Bearer <access_token>` com ao menos papel `viewer`.
+- **Responses:** 200 com `{ "roles": ["<roles resolvidos>"] }`.
 
 ## Admin Ingestion Router (`/api/admin/ingest`)
 
-All endpoints require an API key; list views require `viewer`, mutating actions require `operator` unless noted.【F:app/routers/admin_ingest_api.py†L184-L624】 Models referenced below come from `app.ingestion.models`.【F:app/ingestion/models.py†L1-L674】
+Todos os endpoints exigem um token JWT emitido pelo router de contas; listagens aceitam `viewer`, ações mutáveis exigem `operator` salvo indicação contrária.【F:app/routers/admin_ingest_api.py†L184-L624】 Models referenced below come from `app.ingestion.models`.【F:app/ingestion/models.py†L1-L674】
 
 ### Endpoint overview
 
@@ -184,7 +184,7 @@ All endpoints require an API key; list views require `viewer`, mutating actions 
 
 ## Agent Management Router (`/api/agents`)
 
-All endpoints require API keys; viewer role for reads, operator for writes.【F:app/routers/agents.py†L54-L172】 Pydantic schemas reside in `app.agents.schemas`.【F:app/agents/schemas.py†L1-L188】
+Todos os endpoints requerem tokens bearer emitidos pelo router de contas; `viewer` realiza leituras, operações de escrita exigem `operator` ou `admin`.【F:app/routers/agents.py†L54-L172】 Pydantic schemas residem em `app.agents.schemas`.【F:app/agents/schemas.py†L1-L188】
 
 ### Endpoint overview
 
@@ -225,7 +225,7 @@ All endpoints require API keys; viewer role for reads, operator for writes.【F:
 
 ## Conversation Router
 
-Endpoints live under both `/api/agents/{agent_id}/...` and `/api/conversations/...` and require API keys (`viewer` for reads, `operator` for updates).【F:app/routers/conversations.py†L54-L113】 Schemas reside in `app.conversations.schemas`.【F:app/conversations/schemas.py†L10-L94】
+Endpoints vivem sob `/api/agents/{agent_id}/...` e `/api/conversations/...` e usam o mesmo token bearer (`viewer` para leitura, `operator` para atualização).【F:app/routers/conversations.py†L54-L113】 Schemas residem em `app.conversations.schemas`.【F:app/conversations/schemas.py†L10-L94】
 
 | Method | Path                                             | Role     | Description                                                    |
 | ------ | ------------------------------------------------ | -------- | -------------------------------------------------------------- |

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -53,7 +53,8 @@ Key environment variables (see `.env.example`):
 
 | Variable                                                                       | Description                                                     |
 | ------------------------------------------------------------------------------ | --------------------------------------------------------------- |
-| `ADMIN_API_KEY`, `OP_API_KEY`, `VIEW_API_KEY`                                  | API keys for role‑based ingestion endpoints.                    |
+| `TENANT_TOKEN_SECRET`, `TENANT_TOKEN_ISSUER`, `TENANT_TOKEN_AUDIENCE`          | Parâmetros para assinar e validar JWTs de acesso multi-tenant.  |
+| `ACCESS_TOKEN_TTL_SECONDS`, `REFRESH_TOKEN_TTL_SECONDS`                        | (Opcional) ajustar tempo de expiração dos tokens emitidos.      |
 | `DATABASE_URL` / `PG*`                                                         | PostgreSQL connection details.                                  |
 | `LOG_DIR`, `LOG_LEVEL`, `LOG_JSON`                                             | Logging configuration.                                          |
 | `DOCS_DIR`, `ENABLE_OCR`, `OCR_LANG`                                           | Ingestion and OCR behaviour.                                    |
@@ -112,6 +113,7 @@ Existing workflow `tests.yml` runs on pushes and pull requests:
 - `POST /api/upload` – temporary file storage for chat attachments.
 - `POST /api/ask` – returns answer and source chunks.
 - `POST /api/chat` & `GET /api/chat` – streaming chat responses with optional file attachments.
+- `Router /api/tenant/accounts` – gerencia organizações, login/logout, convites e rotação de tokens de acesso.
 - `Router /api/admin/ingest` – start ingestion jobs (`/local`, `/url`, `/urls`, `/database`, `/api`, `/transcription`), manage connector definitions, inspect job metadata and logs.
 
 #### Connector endpoints

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -42,6 +42,7 @@ class TenantTokenPayload(_TenantTokenRequiredClaims, total=False):
     name: str
     roles: list[str]
     scope: str
+    type: str
 
 
 def _get_env(name: str, *, required: bool = True, default: str | None = None) -> str:
@@ -108,6 +109,9 @@ def decode_tenant_token(token: str) -> TenantTokenPayload:
         raise TenantTokenValidationError(
             "Tenant token payload must include 'tenant_id' and 'user_id'.",
         )
+    token_type = payload.get("type")
+    if token_type and token_type != "access":
+        raise TenantTokenValidationError("Tenant token must be an access token.")
 
     return cast(TenantTokenPayload, payload)
 

--- a/app/main.py
+++ b/app/main.py
@@ -45,7 +45,15 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from .rag import build_context
 from .sse_utils import sse_word_buffer
 from .app_logging import init_logging
-from .routers import admin_ingest_api, auth_api, feedback_api, agents, conversations, webhooks
+from .routers import (
+    admin_ingest_api,
+    agents,
+    auth_api,
+    conversations,
+    feedback_api,
+    tenant_accounts,
+    webhooks,
+)
 from .core.tenant_middleware import TenantContextMiddleware
 from .__version__ import __version__, __build_date__, __commit_sha__
 
@@ -105,6 +113,7 @@ app.include_router(auth_api.router)
 app.include_router(feedback_api.router)
 app.include_router(agents.router)
 app.include_router(conversations.router)
+app.include_router(tenant_accounts.router)
 app.include_router(webhooks.router)
  
 # Expose Prometheus metrics

--- a/app/migrations/011_add_auth_tables.py
+++ b/app/migrations/011_add_auth_tables.py
@@ -1,0 +1,148 @@
+"""Add authentication metadata tables and columns."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "011_add_auth_tables"
+down_revision = "004_create_multi_tenant_tables"
+branch_labels = None
+depends_on = None
+
+
+_UUID = postgresql.UUID(as_uuid=True)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "role",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'viewer'"),
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("timezone('utc', now())"),
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("timezone('utc', now())"),
+        ),
+    )
+
+    op.create_table(
+        "user_invites",
+        sa.Column(
+            "id",
+            _UUID,
+            nullable=False,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "organization_id",
+            _UUID,
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("role", sa.String(length=32), nullable=False),
+        sa.Column("token", sa.String(length=255), nullable=False),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("timezone('utc', now())"),
+        ),
+    )
+    op.create_index(
+        "ix_user_invites_token_unique",
+        "user_invites",
+        ["token"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_user_invites_org",
+        "user_invites",
+        ["organization_id"],
+    )
+
+    op.create_table(
+        "refresh_tokens",
+        sa.Column(
+            "id",
+            _UUID,
+            nullable=False,
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            _UUID,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("token_hash", sa.String(length=255), nullable=False),
+        sa.Column(
+            "issued_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("timezone('utc', now())"),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("user_agent", sa.String(length=255), nullable=True),
+    )
+    op.create_index(
+        "ix_refresh_tokens_user_id",
+        "refresh_tokens",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_refresh_tokens_token_hash",
+        "refresh_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_refresh_tokens_token_hash", table_name="refresh_tokens")
+    op.drop_index("ix_refresh_tokens_user_id", table_name="refresh_tokens")
+    op.drop_table("refresh_tokens")
+
+    op.drop_index("ix_user_invites_org", table_name="user_invites")
+    op.drop_index("ix_user_invites_token_unique", table_name="user_invites")
+    op.drop_table("user_invites")
+
+    op.drop_column("users", "updated_at")
+    op.drop_column("users", "created_at")
+    op.drop_column("users", "is_active")
+    op.drop_column("users", "role")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -17,11 +17,13 @@ class Base(DeclarativeBase):
 
 # Re-export core tenant models for convenience so callers can import them via
 # ``from app.models import Organization`` instead of touching private modules.
-from .tenant import Organization, User
+from .tenant import Organization, RefreshToken, User, UserInvite
 
 
 __all__ = [
     "Base",
     "Organization",
     "User",
+    "UserInvite",
+    "RefreshToken",
 ]

--- a/app/routers/admin_ingest_api.py
+++ b/app/routers/admin_ingest_api.py
@@ -2,7 +2,7 @@
 
 This router exposes endpoints for operators to start ingestion jobs, inspect
 their progress, (re)index sources and read job logs. Access is controlled via
-simple role-based API keys (see security/auth.py).
+JWT bearer tokens emitidos pelo módulo de segurança (`app.security`).
 """
 from __future__ import annotations
 

--- a/app/routers/auth_api.py
+++ b/app/routers/auth_api.py
@@ -1,10 +1,19 @@
 from fastapi import APIRouter, Depends
 
-from ..security.auth import require_role
+from ..core.auth import TenantTokenPayload
+from ..security.auth import get_current_token_payload, require_role
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 
 @router.get("/roles")
-async def get_roles(role: str = Depends(require_role("viewer"))):
-    return {"roles": [role]}
+async def get_roles(
+    role: str = Depends(require_role("viewer")),
+    payload: TenantTokenPayload = Depends(get_current_token_payload),
+):
+    roles = payload.get("roles") or []
+    if isinstance(roles, str):  # pragma: no cover - defensive
+        roles = [roles]
+    if role not in roles:
+        roles.append(role)
+    return {"roles": sorted(set(roles))}

--- a/app/routers/tenant_accounts.py
+++ b/app/routers/tenant_accounts.py
@@ -1,0 +1,451 @@
+"""Tenant account management API."""
+
+from __future__ import annotations
+
+import datetime as dt
+import secrets
+import uuid
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import Organization, User, UserInvite
+from app.security import (
+    create_access_token,
+    create_refresh_token,
+    get_current_user,
+    hash_password,
+    require_role,
+    revoke_all_refresh_tokens,
+    revoke_refresh_token,
+    verify_password,
+    verify_refresh_token,
+)
+from app.security.auth import get_db_session
+
+router = APIRouter(prefix="/api/tenant/accounts", tags=["tenant-accounts"])
+
+_ROLE_CHOICES: tuple[Literal["viewer", "operator", "admin"], ...] = (
+    "viewer",
+    "operator",
+    "admin",
+)
+
+
+class OrganizationPayload(BaseModel):
+    id: uuid.UUID
+    name: str
+    subdomain: str
+    plan_type: str
+
+
+class UserPayload(BaseModel):
+    id: uuid.UUID
+    email: EmailStr
+    name: str
+    role: str
+
+
+class TokenEnvelope(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: Literal["bearer"] = "bearer"
+    expires_in: int = Field(..., description="Seconds until the access token expires")
+    refresh_expires_in: int = Field(
+        ..., description="Seconds until the refresh token expires"
+    )
+    roles: list[str]
+
+
+class AuthenticatedResponse(BaseModel):
+    organization: OrganizationPayload
+    user: UserPayload
+    tokens: TokenEnvelope
+
+
+class RegisterOrganizationRequest(BaseModel):
+    organization_name: str = Field(..., min_length=1, max_length=255)
+    subdomain: str = Field(..., pattern=r"^[a-z0-9-]{3,63}$")
+    admin_name: str = Field(..., min_length=1, max_length=255)
+    admin_email: EmailStr
+    password: str = Field(..., min_length=8, max_length=128)
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class LogoutRequest(BaseModel):
+    refresh_token: str
+
+
+class InviteUserRequest(BaseModel):
+    email: EmailStr
+    role: Literal["viewer", "operator", "admin"] = "viewer"
+    expires_in: int = Field(default=60 * 60 * 24 * 7, ge=300, le=60 * 60 * 24 * 30)
+    message: str | None = Field(default=None, max_length=2000)
+
+
+class InviteResponse(BaseModel):
+    token: str
+    email: EmailStr
+    role: str
+    expires_at: dt.datetime
+
+
+class AcceptInviteRequest(BaseModel):
+    token: str
+    name: str = Field(..., min_length=1, max_length=255)
+    password: str = Field(..., min_length=8, max_length=128)
+
+
+class RotateCredentialsRequest(BaseModel):
+    refresh_token: str
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _normalize_subdomain(subdomain: str) -> str:
+    return subdomain.lower()
+
+
+def _normalize_email(email: str) -> str:
+    return email.lower()
+
+
+def _as_utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
+
+
+def _token_response(
+    *,
+    user: User,
+    access_token: str,
+    access_expires_at: dt.datetime,
+    refresh_token: str,
+    refresh_expires_at: dt.datetime,
+) -> TokenEnvelope:
+    now = _utcnow()
+    access_expires_at = _as_utc(access_expires_at)
+    refresh_expires_at = _as_utc(refresh_expires_at)
+
+    return TokenEnvelope(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_in=max(int((access_expires_at - now).total_seconds()), 0),
+        refresh_expires_in=max(int((refresh_expires_at - now).total_seconds()), 0),
+        roles=[user.role],
+    )
+
+
+def _user_payload(user: User) -> UserPayload:
+    return UserPayload(id=user.id, email=user.email, name=user.name, role=user.role)
+
+
+def _organization_payload(org: Organization) -> OrganizationPayload:
+    return OrganizationPayload(
+        id=org.id,
+        name=org.name,
+        subdomain=org.subdomain,
+        plan_type=org.plan_type,
+    )
+
+
+@router.post("/register", response_model=AuthenticatedResponse, status_code=status.HTTP_201_CREATED)
+def register_organization(
+    payload: RegisterOrganizationRequest,
+    request: Request,
+    session: Session = Depends(get_db_session),
+) -> AuthenticatedResponse:
+    """Create a tenant organization with an administrator user."""
+
+    subdomain = _normalize_subdomain(payload.subdomain)
+    email = _normalize_email(payload.admin_email)
+
+    existing_org = session.execute(
+        select(Organization).where(Organization.subdomain == subdomain)
+    ).scalar_one_or_none()
+    if existing_org:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Subdomain already in use.")
+
+    existing_user = session.execute(select(User).where(User.email == email)).scalar_one_or_none()
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already exists.")
+
+    organization = Organization(name=payload.organization_name, subdomain=subdomain)
+    session.add(organization)
+    session.flush()
+
+    admin_user = User(
+        organization_id=organization.id,
+        email=email,
+        name=payload.admin_name,
+        password_hash=hash_password(payload.password),
+        role="admin",
+    )
+    session.add(admin_user)
+    session.flush()
+
+    user_agent = request.headers.get("User-Agent")
+    refresh_token, refresh_record = create_refresh_token(
+        session, admin_user, user_agent=user_agent
+    )
+    access_token, access_expires_at = create_access_token(admin_user)
+
+    session.commit()
+
+    return AuthenticatedResponse(
+        organization=_organization_payload(organization),
+        user=_user_payload(admin_user),
+        tokens=_token_response(
+            user=admin_user,
+            access_token=access_token,
+            access_expires_at=access_expires_at,
+            refresh_token=refresh_token,
+            refresh_expires_at=refresh_record.expires_at,
+        ),
+    )
+
+
+@router.post("/login", response_model=AuthenticatedResponse)
+def login(
+    payload: LoginRequest,
+    request: Request,
+    session: Session = Depends(get_db_session),
+) -> AuthenticatedResponse:
+    """Authenticate a user via e-mail and password."""
+
+    email = _normalize_email(payload.email)
+    user = session.execute(select(User).where(User.email == email)).scalar_one_or_none()
+    if not user or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials.")
+
+    if not user.is_active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User is inactive.")
+
+    organization = user.organization
+    user_agent = request.headers.get("User-Agent")
+    refresh_token, refresh_record = create_refresh_token(
+        session, user, user_agent=user_agent
+    )
+    access_token, access_expires_at = create_access_token(user)
+
+    session.commit()
+
+    return AuthenticatedResponse(
+        organization=_organization_payload(organization),
+        user=_user_payload(user),
+        tokens=_token_response(
+            user=user,
+            access_token=access_token,
+            access_expires_at=access_expires_at,
+            refresh_token=refresh_token,
+            refresh_expires_at=refresh_record.expires_at,
+        ),
+    )
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+def logout(
+    payload: LogoutRequest,
+    session: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    """Revoke a single refresh token for the authenticated user."""
+
+    token = verify_refresh_token(session, payload.refresh_token)
+    if token is None or token.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid refresh token.")
+
+    revoke_refresh_token(token)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/refresh", response_model=AuthenticatedResponse)
+def refresh(
+    payload: RefreshRequest,
+    request: Request,
+    session: Session = Depends(get_db_session),
+) -> AuthenticatedResponse:
+    """Exchange a refresh token for a new access/refresh pair."""
+
+    token = verify_refresh_token(session, payload.refresh_token)
+    if token is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token.")
+
+    user = session.get(User, token.user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User is inactive.")
+
+    organization = user.organization
+    revoke_refresh_token(token)
+
+    user_agent = request.headers.get("User-Agent")
+    refresh_token, refresh_record = create_refresh_token(
+        session, user, user_agent=user_agent
+    )
+    access_token, access_expires_at = create_access_token(user)
+
+    session.commit()
+
+    return AuthenticatedResponse(
+        organization=_organization_payload(organization),
+        user=_user_payload(user),
+        tokens=_token_response(
+            user=user,
+            access_token=access_token,
+            access_expires_at=access_expires_at,
+            refresh_token=refresh_token,
+            refresh_expires_at=refresh_record.expires_at,
+        ),
+    )
+
+
+@router.post("/invite", response_model=InviteResponse, status_code=status.HTTP_201_CREATED)
+def invite_user(
+    payload: InviteUserRequest,
+    session: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+    _: str = Depends(require_role("admin")),
+) -> InviteResponse:
+    """Issue an invitation for another user to join the organization."""
+
+    email = _normalize_email(payload.email)
+    if payload.role not in _ROLE_CHOICES:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid role.")
+
+    existing_user = session.execute(select(User).where(User.email == email)).scalar_one_or_none()
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already exists.")
+
+    existing_invite = session.execute(
+        select(UserInvite).where(
+            UserInvite.organization_id == current_user.organization_id,
+            UserInvite.email == email,
+            UserInvite.accepted_at.is_(None),
+        )
+    ).scalar_one_or_none()
+    if existing_invite:
+        session.delete(existing_invite)
+        session.flush()
+
+    invite_token = secrets.token_urlsafe(32)
+    expires_at = _utcnow() + dt.timedelta(seconds=payload.expires_in)
+    invite = UserInvite(
+        organization_id=current_user.organization_id,
+        email=email,
+        role=payload.role,
+        token=invite_token,
+        message=payload.message,
+        expires_at=expires_at,
+    )
+    session.add(invite)
+    session.commit()
+
+    return InviteResponse(token=invite_token, email=email, role=payload.role, expires_at=expires_at)
+
+
+@router.post("/accept-invite", response_model=AuthenticatedResponse)
+def accept_invite(
+    payload: AcceptInviteRequest,
+    request: Request,
+    session: Session = Depends(get_db_session),
+) -> AuthenticatedResponse:
+    """Convert an invitation token into an active user account."""
+
+    invite = session.execute(
+        select(UserInvite).where(UserInvite.token == payload.token)
+    ).scalar_one_or_none()
+    if invite is None or invite.accepted_at is not None or _as_utc(invite.expires_at) <= _utcnow():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired invite.")
+
+    email = _normalize_email(invite.email)
+    existing_user = session.execute(select(User).where(User.email == email)).scalar_one_or_none()
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already exists.")
+
+    user = User(
+        organization_id=invite.organization_id,
+        email=email,
+        name=payload.name,
+        password_hash=hash_password(payload.password),
+        role=invite.role,
+    )
+    session.add(user)
+    invite.accepted_at = _utcnow()
+    session.flush()
+
+    organization = session.get(Organization, invite.organization_id)
+    if organization is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found.")
+
+    user_agent = request.headers.get("User-Agent")
+    refresh_token, refresh_record = create_refresh_token(
+        session, user, user_agent=user_agent
+    )
+    access_token, access_expires_at = create_access_token(user)
+
+    session.commit()
+
+    return AuthenticatedResponse(
+        organization=_organization_payload(organization),
+        user=_user_payload(user),
+        tokens=_token_response(
+            user=user,
+            access_token=access_token,
+            access_expires_at=access_expires_at,
+            refresh_token=refresh_token,
+            refresh_expires_at=refresh_record.expires_at,
+        ),
+    )
+
+
+@router.post("/rotate-credentials", response_model=AuthenticatedResponse)
+def rotate_credentials(
+    payload: RotateCredentialsRequest,
+    request: Request,
+    session: Session = Depends(get_db_session),
+    current_user: User = Depends(get_current_user),
+) -> AuthenticatedResponse:
+    """Invalidate all existing refresh tokens and issue a fresh pair."""
+
+    token = verify_refresh_token(session, payload.refresh_token)
+    if token is None or token.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token.")
+
+    revoke_all_refresh_tokens(session, current_user)
+
+    user_agent = request.headers.get("User-Agent")
+    refresh_token, refresh_record = create_refresh_token(
+        session, current_user, user_agent=user_agent
+    )
+    access_token, access_expires_at = create_access_token(current_user)
+
+    session.commit()
+
+    organization = current_user.organization
+
+    return AuthenticatedResponse(
+        organization=_organization_payload(organization),
+        user=_user_payload(current_user),
+        tokens=_token_response(
+            user=current_user,
+            access_token=access_token,
+            access_expires_at=access_expires_at,
+            refresh_token=refresh_token,
+            refresh_expires_at=refresh_record.expires_at,
+        ),
+    )

--- a/app/security/__init__.py
+++ b/app/security/__init__.py
@@ -1,1 +1,30 @@
-from .auth import require_role
+"""Security utilities exposed for convenience."""
+
+from .auth import get_current_token_payload, get_current_user, require_role
+from .passwords import hash_password, verify_password
+from .tokens import (
+    JWTSettings,
+    create_access_token,
+    create_refresh_token,
+    get_jwt_settings,
+    reset_jwt_settings_cache,
+    revoke_all_refresh_tokens,
+    revoke_refresh_token,
+    verify_refresh_token,
+)
+
+__all__ = [
+    "JWTSettings",
+    "create_access_token",
+    "create_refresh_token",
+    "get_current_token_payload",
+    "get_current_user",
+    "get_jwt_settings",
+    "hash_password",
+    "require_role",
+    "reset_jwt_settings_cache",
+    "revoke_all_refresh_tokens",
+    "revoke_refresh_token",
+    "verify_password",
+    "verify_refresh_token",
+]

--- a/app/security/auth.py
+++ b/app/security/auth.py
@@ -1,90 +1,121 @@
-"""Simple API-key based role authentication for FastAPI routers.
-
-This module reads single API keys for roles from environment variables and
-exposes a dependency factory ``require_role(min_role)`` that validates
-``X-API-Key`` headers.
-
-Role hierarchy (least → most privileged): ``viewer`` < ``operator`` < ``admin``.
-
-Note: keys are loaded at import time; if you change the environment, restart
-the server for changes to take effect.
-"""
+"""JWT-backed authentication dependencies for FastAPI routers."""
 
 from __future__ import annotations
 
-import os
+import uuid
+from collections.abc import Iterator
 from typing import Callable
 
-from fastapi import Header, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session, sessionmaker
 
-# Role hierarchy: higher number means more privileges
+from app.core.auth import TenantTokenPayload, get_tenant_context
+from app.models import User
+from app.models.session import get_sessionmaker
+
+
 _ROLE_LEVELS = {"viewer": 0, "operator": 1, "admin": 2}
+_SESSION_FACTORY: sessionmaker[Session] | None = None
 
 
-def _load_api_key_roles() -> dict[str, str]:
-    """Load API keys for each role from environment variables.
-
-    Environment variables expected:
-    - ``VIEW_API_KEY`` (default: ``view``)
-    - ``OP_API_KEY`` (default: ``oper``)
-    - ``ADMIN_API_KEY`` (default: ``admin``)
-
-    Each variable holds a single key for that role.
-    """
-
-    mapping: dict[str, str] = {}
-    for env, role, default in [
-        ("VIEW_API_KEY", "viewer", "view"),
-        ("OP_API_KEY", "operator", "oper"),
-        ("ADMIN_API_KEY", "admin", "admin"),
-    ]:
-        key = os.getenv(env, default).strip()
-        if key:
-            mapping[key] = role
-    return mapping
+def _get_session_factory() -> sessionmaker[Session]:
+    global _SESSION_FACTORY
+    if _SESSION_FACTORY is None:
+        _SESSION_FACTORY = get_sessionmaker()
+    return _SESSION_FACTORY
 
 
-_API_KEY_ROLES = _load_api_key_roles()
+def get_db_session() -> Iterator[Session]:
+    """Yield a SQLAlchemy session for request-scoped dependencies."""
+
+    session = _get_session_factory()()
+    try:
+        yield session
+    finally:
+        session.close()
 
 
-def require_role(min_role: str) -> Callable:
-    """Create a dependency to validate the caller's role.
+async def get_current_token_payload(request: Request) -> TenantTokenPayload:
+    """Decode and validate the bearer token from ``request``."""
 
-    The caller must supply an ``X-API-Key`` header whose value maps to a role
-    with at least ``min_role`` privileges.
+    payload = await get_tenant_context(request)
+    token_type = payload.get("type")
+    if token_type and token_type != "access":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Access token required.",
+        )
+    return payload
 
-    Parameters
-    ----------
-    min_role:
-        Minimum role name required (``viewer``, ``operator`` or ``admin``).
 
-    Returns
-    -------
-    Callable
-        FastAPI dependency that returns the resolved role string on success and
-        raises ``HTTPException`` on failure.
-    """
+async def get_current_user(
+    payload: TenantTokenPayload = Depends(get_current_token_payload),
+    session: Session = Depends(get_db_session),
+) -> User:
+    """Resolve the authenticated :class:`~app.models.User` from the token payload."""
+
+    try:
+        user_id = uuid.UUID(payload["user_id"])
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid user identifier in token.",
+        ) from exc
+
+    user = session.get(User, user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User is inactive or no longer exists.",
+        )
+
+    if str(user.organization_id) != payload.get("tenant_id"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token tenant mismatch.",
+        )
+
+    return user
+
+
+def _highest_role(roles: list[str]) -> str | None:
+    ranked = sorted({role for role in roles if role in _ROLE_LEVELS}, key=_ROLE_LEVELS.get)
+    return ranked[-1] if ranked else None
+
+
+def require_role(min_role: str) -> Callable[..., str]:
+    """Create a dependency ensuring the caller has at least ``min_role`` privileges."""
 
     if min_role not in _ROLE_LEVELS:
         raise ValueError(f"Unknown role: {min_role}")
 
-    async def dependency(x_api_key: str | None = Header(default=None)) -> str:
-        if not x_api_key:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Missing API key",
-            )
-        role = _API_KEY_ROLES.get(x_api_key)
-        if not role:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid API key",
-            )
-        if _ROLE_LEVELS[role] < _ROLE_LEVELS[min_role]:
+    async def dependency(
+        user: User = Depends(get_current_user),
+        payload: TenantTokenPayload = Depends(get_current_token_payload),
+    ) -> str:
+        roles = payload.get("roles") or []
+        if isinstance(roles, str):  # pragma: no cover - defensive
+            roles = [roles]
+        combined_roles = list(roles) + [user.role]
+        highest = _highest_role(combined_roles)
+        if highest is None:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail="Insufficient role",
+                detail="No roles assigned to user.",
             )
-        return role
+        if _ROLE_LEVELS[highest] < _ROLE_LEVELS[min_role]:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient role.",
+            )
+        return highest
 
     return dependency
+
+
+__all__ = [
+    "get_current_token_payload",
+    "get_current_user",
+    "get_db_session",
+    "require_role",
+]

--- a/app/security/passwords.py
+++ b/app/security/passwords.py
@@ -1,0 +1,27 @@
+"""Password hashing utilities backed by Passlib (Argon2)."""
+
+from __future__ import annotations
+
+from passlib.context import CryptContext
+
+
+_pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Return a secure hash for ``password`` using Argon2."""
+
+    if not password:
+        raise ValueError("Password must be non-empty.")
+    return _pwd_context.hash(password)
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    """Validate ``password`` against ``hashed_password``."""
+
+    if not hashed_password:
+        return False
+    return _pwd_context.verify(password, hashed_password)
+
+
+__all__ = ["hash_password", "verify_password"]

--- a/app/security/tokens.py
+++ b/app/security/tokens.py
@@ -1,0 +1,181 @@
+"""Helpers for issuing and managing JWT access/refresh tokens."""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import hashlib
+import os
+import secrets
+from functools import lru_cache
+from typing import Any, Iterable
+
+import jwt
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from app.models import RefreshToken, User
+
+
+@dataclasses.dataclass(frozen=True)
+class JWTSettings:
+    """Runtime configuration for issuing authentication tokens."""
+
+    secret: str
+    issuer: str
+    audience: str
+    algorithm: str = "HS256"
+    access_token_ttl_seconds: int = 900  # 15 minutes
+    refresh_token_ttl_seconds: int = 60 * 60 * 24 * 14  # two weeks
+
+
+@lru_cache(maxsize=1)
+def get_jwt_settings() -> JWTSettings:
+    """Load settings from the environment with sane defaults for development."""
+
+    secret = os.getenv("TENANT_TOKEN_SECRET")
+    issuer = os.getenv("TENANT_TOKEN_ISSUER")
+    audience = os.getenv("TENANT_TOKEN_AUDIENCE")
+    algorithm = os.getenv("TENANT_TOKEN_ALGORITHM", "HS256")
+    if not secret or not issuer or not audience:
+        raise RuntimeError(
+            "TENANT_TOKEN_SECRET, TENANT_TOKEN_ISSUER and TENANT_TOKEN_AUDIENCE must be set.",
+        )
+    access_ttl = int(os.getenv("ACCESS_TOKEN_TTL_SECONDS", "900"))
+    refresh_ttl = int(os.getenv("REFRESH_TOKEN_TTL_SECONDS", str(60 * 60 * 24 * 14)))
+    return JWTSettings(
+        secret=secret,
+        issuer=issuer,
+        audience=audience,
+        algorithm=algorithm,
+        access_token_ttl_seconds=access_ttl,
+        refresh_token_ttl_seconds=refresh_ttl,
+    )
+
+
+def reset_jwt_settings_cache() -> None:
+    """Clear cached JWT settings; useful in tests when env vars change."""
+
+    get_jwt_settings.cache_clear()
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _as_utc(value: dt.datetime) -> dt.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=dt.timezone.utc)
+    return value.astimezone(dt.timezone.utc)
+
+
+def _user_roles(user: User) -> list[str]:
+    roles: Iterable[str]
+    if isinstance(user.role, str):
+        roles = [user.role]
+    else:  # pragma: no cover - defensive, role stored as str
+        roles = list(user.role)
+    return [role for role in roles if role]
+
+
+def create_access_token(user: User, *, settings: JWTSettings | None = None) -> tuple[str, dt.datetime]:
+    """Issue a signed JWT access token for ``user``."""
+
+    settings = settings or get_jwt_settings()
+    now = _utcnow()
+    expires_at = now + dt.timedelta(seconds=settings.access_token_ttl_seconds)
+    payload: dict[str, Any] = {
+        "tenant_id": str(user.organization_id),
+        "user_id": str(user.id),
+        "email": user.email,
+        "name": user.name,
+        "roles": _user_roles(user),
+        "iss": settings.issuer,
+        "aud": settings.audience,
+        "iat": int(now.timestamp()),
+        "exp": int(expires_at.timestamp()),
+        "scope": "tenant",
+        "type": "access",
+    }
+    token = jwt.encode(payload, settings.secret, algorithm=settings.algorithm)
+    return str(token), expires_at
+
+
+def create_refresh_token(
+    session: Session,
+    user: User,
+    *,
+    user_agent: str | None = None,
+    settings: JWTSettings | None = None,
+) -> tuple[str, RefreshToken]:
+    """Persist a refresh token bound to ``user`` and return the raw secret."""
+
+    settings = settings or get_jwt_settings()
+    raw_token = secrets.token_urlsafe(48)
+    hashed = _hash_token(raw_token)
+    now = _utcnow()
+    expires_at = now + dt.timedelta(seconds=settings.refresh_token_ttl_seconds)
+    record = RefreshToken(
+        user_id=user.id,
+        token_hash=hashed,
+        issued_at=now,
+        expires_at=expires_at,
+        user_agent=user_agent,
+    )
+    session.add(record)
+    session.flush()
+    return raw_token, record
+
+
+def verify_refresh_token(session: Session, raw_token: str) -> RefreshToken | None:
+    """Return the refresh token row matching ``raw_token`` if valid."""
+
+    if not raw_token:
+        return None
+    hashed = _hash_token(raw_token)
+    token = session.execute(
+        select(RefreshToken).where(RefreshToken.token_hash == hashed)
+    ).scalar_one_or_none()
+    if token is None:
+        return None
+    if token.revoked_at is not None:
+        return None
+    if _as_utc(token.expires_at) <= _utcnow():
+        return None
+    return token
+
+
+def revoke_refresh_token(token: RefreshToken, *, when: dt.datetime | None = None) -> None:
+    """Mark ``token`` as revoked."""
+
+    token.revoked_at = when or _utcnow()
+
+
+def revoke_all_refresh_tokens(session: Session, user: User, *, when: dt.datetime | None = None) -> int:
+    """Revoke every refresh token for ``user`` and return the count."""
+
+    when = when or _utcnow()
+    result = session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.user_id == user.id)
+        .where(RefreshToken.revoked_at.is_(None))
+        .values(revoked_at=when)
+        .execution_options(synchronize_session="fetch")
+    )
+    return int(result.rowcount or 0)
+
+
+__all__ = [
+    "JWTSettings",
+    "create_access_token",
+    "create_refresh_token",
+    "get_jwt_settings",
+    "reset_jwt_settings_cache",
+    "revoke_all_refresh_tokens",
+    "revoke_refresh_token",
+    "verify_refresh_token",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pytest>=8.0
 slowapi>=0.1.8
 langdetect>=1.0.9
 PyJWT>=2.8.0
+passlib[argon2]>=1.7.4
 pytesseract
 pdf2image
 Pillow

--- a/tests/test_admin_ingest_api_extended.py
+++ b/tests/test_admin_ingest_api_extended.py
@@ -14,21 +14,18 @@ from app.ingestion.models import (
 )
 
 
-def create_client(monkeypatch):
-    monkeypatch.setenv("VIEW_API_KEY", "view")
-    monkeypatch.setenv("OP_API_KEY", "oper")
-    monkeypatch.setenv("ADMIN_API_KEY", "admin")
+def create_client(monkeypatch, tenant_auth):
     import app.security.auth as auth
     importlib.reload(auth)
     import app.routers.admin_ingest_api as admin_api
     importlib.reload(admin_api)
     import app.main as main
     importlib.reload(main)
-    return TestClient(main.app), admin_api
+    return TestClient(main.app), admin_api, tenant_auth
 
 
-def test_start_local_job_auth_validation(monkeypatch):
-    client, admin_api = create_client(monkeypatch)
+def test_start_local_job_auth_validation(monkeypatch, tenant_auth):
+    client, admin_api, auth_ctx = create_client(monkeypatch, tenant_auth)
     dummy_id = uuid4()
     monkeypatch.setattr(admin_api.service, "ingest_local", lambda *a, **k: dummy_id)
 
@@ -42,44 +39,44 @@ def test_start_local_job_auth_validation(monkeypatch):
     res = client.post(
         "/api/admin/ingest/local",
         json={"path": "/tmp/a"},
-        headers={"X-API-Key": "view"},
+        headers=auth_ctx.header("viewer"),
     )
     assert res.status_code == 403
 
     # validation error missing path
-    res = client.post("/api/admin/ingest/local", headers={"X-API-Key": "oper"})
+    res = client.post("/api/admin/ingest/local", headers=auth_ctx.header("operator"))
     assert res.status_code == 422
 
     # operator success
     res = client.post(
         "/api/admin/ingest/local",
         json={"path": "/tmp/a"},
-        headers={"X-API-Key": "oper"},
+        headers=auth_ctx.header("operator"),
     )
     assert res.status_code == 200
     assert res.json()["job_id"] == str(dummy_id)
 
 
-def test_start_urls_job_validation(monkeypatch):
-    client, admin_api = create_client(monkeypatch)
+def test_start_urls_job_validation(monkeypatch, tenant_auth):
+    client, admin_api, auth_ctx = create_client(monkeypatch, tenant_auth)
     dummy_id = uuid4()
     monkeypatch.setattr(admin_api.service, "ingest_urls", lambda urls: dummy_id)
 
     # validation error for body
-    res = client.post("/api/admin/ingest/urls", headers={"X-API-Key": "oper"})
+    res = client.post("/api/admin/ingest/urls", headers=auth_ctx.header("operator"))
     assert res.status_code == 422
 
     res = client.post(
         "/api/admin/ingest/urls",
         json={"urls": ["http://a"]},
-        headers={"X-API-Key": "oper"},
+        headers=auth_ctx.header("operator"),
     )
     assert res.status_code == 200
     assert res.json()["job_id"] == str(dummy_id)
 
 
-def test_sources_crud_and_reindex(monkeypatch):
-    client, admin_api = create_client(monkeypatch)
+def test_sources_crud_and_reindex(monkeypatch, tenant_auth):
+    client, admin_api, auth_ctx = create_client(monkeypatch, tenant_auth)
     sources: dict[UUID, Source] = {}
 
     class DummyConn:
@@ -129,13 +126,13 @@ def test_sources_crud_and_reindex(monkeypatch):
     res = client.post(
         "/api/admin/ingest/sources",
         json={"type": "local_dir", "path": "/a"},
-        headers={"X-API-Key": "oper"},
+        headers=auth_ctx.header("operator"),
     )
     assert res.status_code == 200
     sid = UUID(res.json()["id"])
 
     # list
-    res = client.get("/api/admin/ingest/sources", headers={"X-API-Key": "view"})
+    res = client.get("/api/admin/ingest/sources", headers=auth_ctx.header("viewer"))
     assert res.status_code == 200
     assert len(res.json()["items"]) == 1
 
@@ -143,14 +140,14 @@ def test_sources_crud_and_reindex(monkeypatch):
     res = client.put(
         f"/api/admin/ingest/sources/{sid}",
         json={"path": "/b"},
-        headers={"X-API-Key": "oper"},
+        headers=auth_ctx.header("operator"),
     )
     assert res.status_code == 200
 
     # reindex
     res = client.post(
         f"/api/admin/ingest/sources/{sid}/reindex",
-        headers={"X-API-Key": "oper"},
+        headers=auth_ctx.header("operator"),
     )
     assert res.status_code == 200
     assert called["rid"] == sid
@@ -158,17 +155,17 @@ def test_sources_crud_and_reindex(monkeypatch):
     # delete
     res = client.delete(
         f"/api/admin/ingest/sources/{sid}",
-        headers={"X-API-Key": "oper"},
+        headers=auth_ctx.header("operator"),
     )
     assert res.status_code == 200
 
-    res = client.get("/api/admin/ingest/sources", headers={"X-API-Key": "view"})
+    res = client.get("/api/admin/ingest/sources", headers=auth_ctx.header("viewer"))
     assert res.status_code == 200
     assert res.json()["items"] == []
 
 
-def test_job_lifecycle_and_logs(monkeypatch):
-    client, admin_api = create_client(monkeypatch)
+def test_job_lifecycle_and_logs(monkeypatch, tenant_auth):
+    client, admin_api, auth_ctx = create_client(monkeypatch, tenant_auth)
     jobs: dict[UUID, Job] = {}
     slices = [
         JobLogSlice(content="line1\n", next_offset=6, status=None),
@@ -206,23 +203,23 @@ def test_job_lifecycle_and_logs(monkeypatch):
     res = client.post(
         "/api/admin/ingest/url",
         json={"url": "http://example.com"},
-        headers={"X-API-Key": "oper"},
+        headers=auth_ctx.header("operator"),
     )
     job_id = UUID(res.json()["job_id"])
 
-    res = client.get("/api/admin/ingest/jobs", headers={"X-API-Key": "view"})
+    res = client.get("/api/admin/ingest/jobs", headers=auth_ctx.header("viewer"))
     assert res.status_code == 200
     assert len(res.json()["items"]) == 1
 
     res = client.post(
         f"/api/admin/ingest/jobs/{job_id}/cancel",
-        headers={"X-API-Key": "oper"},
+        headers=auth_ctx.header("operator"),
     )
     assert res.status_code == 200
     assert jobs[job_id].status == JobStatus.CANCELED
 
     res = client.get(
-        f"/api/admin/ingest/jobs/{job_id}/logs", headers={"X-API-Key": "view"}
+        f"/api/admin/ingest/jobs/{job_id}/logs", headers=auth_ctx.header("viewer")
     )
     assert res.status_code == 200
     data = res.json()
@@ -232,28 +229,28 @@ def test_job_lifecycle_and_logs(monkeypatch):
     res = client.get(
         f"/api/admin/ingest/jobs/{job_id}/logs",
         params={"offset": data["next_offset"]},
-        headers={"X-API-Key": "view"},
+        headers=auth_ctx.header("viewer"),
     )
     data = res.json()
     assert "line2" in data["content"]
     assert data["status"] == JobStatus.SUCCEEDED
 
 
-def test_rerun_job_endpoint(monkeypatch):
-    client, admin_api = create_client(monkeypatch)
+def test_rerun_job_endpoint(monkeypatch, tenant_auth):
+    client, admin_api, auth_ctx = create_client(monkeypatch, tenant_auth)
     orig = uuid4()
     new_id = uuid4()
     monkeypatch.setattr(admin_api.service, "rerun_job", lambda jid: new_id)
 
     res = client.post(
-        f"/api/admin/ingest/jobs/{orig}/rerun", headers={"X-API-Key": "oper"}
+        f"/api/admin/ingest/jobs/{orig}/rerun", headers=auth_ctx.header("operator")
     )
     assert res.status_code == 200
     assert res.json()["job_id"] == str(new_id)
 
 
-def test_jobs_pagination_filters(monkeypatch):
-    client, admin_api = create_client(monkeypatch)
+def test_jobs_pagination_filters(monkeypatch, tenant_auth):
+    client, admin_api, auth_ctx = create_client(monkeypatch, tenant_auth)
     jobs = [
         Job(id=uuid4(), source_id=uuid4(), status=JobStatus.QUEUED, created_at=datetime.utcnow()),
         Job(id=uuid4(), source_id=uuid4(), status=JobStatus.SUCCEEDED, created_at=datetime.utcnow()),
@@ -265,7 +262,7 @@ def test_jobs_pagination_filters(monkeypatch):
     res = client.get(
         "/api/admin/ingest/jobs",
         params={"status": "queued", "limit": 1, "offset": 1},
-        headers={"X-API-Key": "view"},
+        headers=auth_ctx.header("viewer"),
     )
     assert res.status_code == 200
     data = res.json()
@@ -273,8 +270,8 @@ def test_jobs_pagination_filters(monkeypatch):
     assert len(data["items"]) == 1
 
 
-def test_sources_pagination_filters(monkeypatch):
-    client, admin_api = create_client(monkeypatch)
+def test_sources_pagination_filters(monkeypatch, tenant_auth):
+    client, admin_api, auth_ctx = create_client(monkeypatch, tenant_auth)
     sources = [
         Source(id=uuid4(), type=SourceType.URL, url="http://a", path=None, created_at=datetime.utcnow(), active=True),
         Source(id=uuid4(), type=SourceType.URL, url="http://b", path=None, created_at=datetime.utcnow(), active=True),
@@ -301,7 +298,7 @@ def test_sources_pagination_filters(monkeypatch):
     res = client.get(
         "/api/admin/ingest/sources",
         params={"type": "url", "limit": 1, "offset": 0},
-        headers={"X-API-Key": "view"},
+        headers=auth_ctx.header("viewer"),
     )
     assert res.status_code == 200
     data = res.json()

--- a/tests/test_auth_roles.py
+++ b/tests/test_auth_roles.py
@@ -1,22 +1,31 @@
+import importlib
+
 from fastapi.testclient import TestClient
-from fastapi.testclient import TestClient
 
-from app.main import app
-
-client = TestClient(app)
+import app.main as main
+import app.security.auth as security_auth
 
 
-def test_roles_endpoint_valid_key():
-    res = client.get("/api/auth/roles", headers={"X-API-Key": "view"})
+def _create_client() -> TestClient:
+    importlib.reload(security_auth)
+    importlib.reload(main)
+    return TestClient(main.app)
+
+
+def test_roles_endpoint_valid_token(tenant_auth):
+    client = _create_client()
+    res = client.get("/api/auth/roles", headers=tenant_auth.header("viewer"))
     assert res.status_code == 200
     assert res.json() == {"roles": ["viewer"]}
 
 
-def test_roles_endpoint_missing_key():
+def test_roles_endpoint_missing_token(tenant_auth):
+    client = _create_client()
     res = client.get("/api/auth/roles")
     assert res.status_code == 401
 
 
-def test_roles_endpoint_invalid_key():
-    res = client.get("/api/auth/roles", headers={"X-API-Key": "bad"})
+def test_roles_endpoint_invalid_token(tenant_auth):
+    client = _create_client()
+    res = client.get("/api/auth/roles", headers={"Authorization": "Bearer invalid"})
     assert res.status_code == 401

--- a/tests/test_core_auth.py
+++ b/tests/test_core_auth.py
@@ -73,6 +73,15 @@ def test_decode_tenant_token_missing_required_claims(token_env: None) -> None:
         decode_tenant_token(token)
 
 
+def test_decode_tenant_token_requires_access_type(token_env: None) -> None:
+    """Tokens that are not access tokens are rejected."""
+
+    token = _issue_token(type="refresh")
+
+    with pytest.raises(TenantTokenValidationError):
+        decode_tenant_token(token)
+
+
 def test_decode_tenant_token_configuration_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Missing configuration raises a configuration error."""
 

--- a/tests/test_tenant_accounts_api.py
+++ b/tests/test_tenant_accounts_api.py
@@ -1,0 +1,128 @@
+import importlib
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.models import RefreshToken, User
+
+
+def create_client(monkeypatch, tenant_auth):
+    import app.security.auth as security_auth
+    importlib.reload(security_auth)
+    import app.routers.tenant_accounts as tenant_router
+    importlib.reload(tenant_router)
+    import app.main as main
+    importlib.reload(main)
+    return TestClient(main.app)
+
+
+def test_register_login_refresh_logout(monkeypatch, tenant_auth):
+    client = create_client(monkeypatch, tenant_auth)
+
+    register_payload = {
+        "organization_name": "New Org",
+        "subdomain": f"org-{uuid4().hex[:6]}",
+        "admin_name": "Org Owner",
+        "admin_email": "owner@neworg.example",
+        "password": "SuperSecret123!",
+    }
+
+    response = client.post("/api/tenant/accounts/register", json=register_payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["user"]["email"] == "owner@neworg.example"
+    assert data["user"]["role"] == "admin"
+
+    login_response = client.post(
+        "/api/tenant/accounts/login",
+        json={"email": register_payload["admin_email"], "password": register_payload["password"]},
+    )
+    assert login_response.status_code == 200
+    login_data = login_response.json()
+    refresh_token = login_data["tokens"]["refresh_token"]
+
+    refresh_response = client.post(
+        "/api/tenant/accounts/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    assert refresh_response.status_code == 200
+    refreshed = refresh_response.json()["tokens"]
+    new_refresh = refreshed["refresh_token"]
+    access_token = refreshed["access_token"]
+
+    reuse_response = client.post(
+        "/api/tenant/accounts/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    assert reuse_response.status_code == 401
+
+    logout_response = client.post(
+        "/api/tenant/accounts/logout",
+        json={"refresh_token": new_refresh},
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert logout_response.status_code == 204
+
+    post_logout = client.post(
+        "/api/tenant/accounts/refresh",
+        json={"refresh_token": new_refresh},
+    )
+    assert post_logout.status_code == 401
+
+
+def test_invite_accept_and_rotate(monkeypatch, tenant_auth):
+    client = create_client(monkeypatch, tenant_auth)
+
+    invite_payload = {
+        "email": "analyst@tenant.example",
+        "role": "viewer",
+        "expires_in": 3600,
+        "message": "Welcome!",
+    }
+
+    invite_response = client.post(
+        "/api/tenant/accounts/invite",
+        json=invite_payload,
+        headers=tenant_auth.header("admin"),
+    )
+    assert invite_response.status_code == 201
+    invite_token = invite_response.json()["token"]
+
+    accept_response = client.post(
+        "/api/tenant/accounts/accept-invite",
+        json={"token": invite_token, "name": "Analyst", "password": tenant_auth.password},
+    )
+    assert accept_response.status_code == 200
+    accepted = accept_response.json()
+    new_refresh = accepted["tokens"]["refresh_token"]
+    new_access = accepted["tokens"]["access_token"]
+
+    with tenant_auth.session_factory() as session:
+        user = session.execute(
+            select(User).where(User.email == "analyst@tenant.example")
+        ).scalar_one()
+        assert user.role == "viewer"
+        token_row = session.execute(select(RefreshToken).where(RefreshToken.user_id == user.id)).scalar_one()
+        assert token_row.revoked_at is None
+
+    rotate_response = client.post(
+        "/api/tenant/accounts/rotate-credentials",
+        json={"refresh_token": new_refresh},
+        headers={"Authorization": f"Bearer {new_access}"},
+    )
+    assert rotate_response.status_code == 200
+    rotated = rotate_response.json()["tokens"]
+    rotated_refresh = rotated["refresh_token"]
+
+    reuse_old_refresh = client.post(
+        "/api/tenant/accounts/refresh",
+        json={"refresh_token": new_refresh},
+    )
+    assert reuse_old_refresh.status_code == 401
+
+    refresh_rotated = client.post(
+        "/api/tenant/accounts/refresh",
+        json={"refresh_token": rotated_refresh},
+    )
+    assert refresh_rotated.status_code == 200

--- a/tests/test_tenant_middleware.py
+++ b/tests/test_tenant_middleware.py
@@ -82,7 +82,7 @@ def client_factory(monkeypatch: pytest.MonkeyPatch) -> Callable[[], tuple[TestCl
     def _factory() -> tuple[TestClient, DummyConnection]:
         connection = DummyConnection(statements=[])
         app = _create_app(monkeypatch, connection)
-        client = TestClient(app)
+        client = TestClient(app, raise_server_exceptions=False)
         return client, connection
 
     return _factory
@@ -104,6 +104,8 @@ def tenant_token_factory() -> Callable[..., str]:
             "aud": "chatvolt",
             "iss": "auth.chatvolt",
             "exp": int(time.time()) + expires_in,
+            "type": "access",
+            "scope": "tenant",
         }
         token = jwt.encode(payload, "secret-key", algorithm="HS256")
         return str(token)

--- a/tests/test_tenant_models.py
+++ b/tests/test_tenant_models.py
@@ -50,6 +50,7 @@ def test_can_persist_organization_and_user(session: Session) -> None:
     assert user.organization_id == organization.id
     assert user.organization is organization
     assert organization.users == [user]
+    assert user.role == "viewer"
 
 
 def test_unique_subdomain_constraint(session: Session) -> None:


### PR DESCRIPTION
## Summary
- add tenant account management router with register/login/invite flows plus Alembic migration and security helpers
- adjust SQLAlchemy engine setup and tenant middleware for sqlite-friendly tenant context handling
- update docs and tests for JWT-based tenant auth and refresh tokens

## Testing
- pytest tests/test_admin_ingest_api.py tests/test_admin_ingest_api_extended.py tests/test_agents_api.py tests/test_core_auth.py tests/test_tenant_middleware.py tests/test_tenant_models.py -q
- pytest tests/test_tenant_accounts_api.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691505e7b0c08323900c49cc3c13d1bb)